### PR TITLE
Add email scope to facebook login

### DIFF
--- a/src/components/pages/authentication/social/FacebookButton.js
+++ b/src/components/pages/authentication/social/FacebookButton.js
@@ -119,7 +119,7 @@ class FacebookButton extends Component {
 		let style = { background: "#4267B2", color: "white" };
 		let onClick = () => {
 			this.setState({ isAuthenticating: true });
-			window.FB.login(this.onFBSignIn.bind(this));
+			window.FB.login(this.onFBSignIn.bind(this), {scope: 'email'});
 		};
 
 		if (authenticated) {


### PR DESCRIPTION
Relates to https://github.com/big-neon/bn-api/pull/218

Tested it locally and was able to authorize the email permission and login while in the associated branch for the API.