### PR TITLE
Protect the live branch

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-protected_branch='testbbb'
+protected_branch='live'
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
 if [ $protected_branch = $current_branch ]
 then
-    read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+    read -p "You're about to push to $protected_branch, is that what you intended? [y|n] " -n 1 -r < /dev/tty
     echo
     if echo $REPLY | grep -E '^[Yy]$' > /dev/null
     then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+protected_branch='testbbb'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ $protected_branch = $current_branch ]
+then
+    read -p "You're about to push master, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+    echo
+    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+    then
+        exit 0 # push will execute
+    fi
+    exit 1 # push will not execute
+else
+    exit 0 # push will execute
+fi


### PR DESCRIPTION
A pre-push githook that will prompt you if you are pushing to the `live` branch to prevent accidental pushes that will get deployed.

Make sure you are using the project hooks path
`git config --set core.hooksPath .githooks`