### PR TITLE
Fixes for max_per_user and availability count issues for discount codes

### DIFF
--- a/src/components/pages/admin/events/dashboard/codes/CodeDialog.js
+++ b/src/components/pages/admin/events/dashboard/codes/CodeDialog.js
@@ -57,7 +57,7 @@ const formatCodeForSaving = values => {
 
 	let max_per_users = {};
 	if (maxTicketsPerUser && Number(maxTicketsPerUser) > 0) {
-		max_per_users = { max_per_user: (maxTicketsPerUser) };
+		max_per_users = { max_tickets_per_user: Number(maxTicketsPerUser) };
 	}
 
 	const result = {
@@ -83,7 +83,7 @@ const createCodeForInput = (values = {}) => {
 		discount_in_cents,
 		discount_as_percentage,
 		max_uses,
-		max_per_user,
+		max_tickets_per_user,
 		end_date,
 		start_date,
 		ticket_type_ids,
@@ -107,7 +107,7 @@ const createCodeForInput = (values = {}) => {
 		discountAsPercentage: discount_as_percentage
 			? discount_as_percentage
 			: "",
-		maxTicketsPerUser: max_per_user || "",
+		maxTicketsPerUser: max_tickets_per_user || "",
 		startDate: start_date
 			? moment.utc(start_date, moment.HTML5_FMT.DATETIME_LOCAL_MS).local()
 			: moment.utc().local(),
@@ -342,7 +342,7 @@ class CodeDialog extends React.Component {
 					end_date,
 					start_date
 				});
-
+				console.log(formattedCode);
 				storeFunction(formattedCode)
 					.then(response => {
 						const { id } = response.data;

--- a/src/components/pages/admin/events/dashboard/codes/List.js
+++ b/src/components/pages/admin/events/dashboard/codes/List.js
@@ -134,7 +134,8 @@ class CodeList extends Component {
 							ticket_type_ids,
 							discount_in_cents,
 							discount_as_percentage,
-							max_uses
+							max_uses,
+							available
 						} = c;
 
 						const ticketTypesList = [];
@@ -159,7 +160,7 @@ class CodeList extends Component {
 								? null
 								: ticketTypeDisplayList,
 							discount_in_cents ? "$ " + (discount_in_cents / 100).toFixed(2) : discount_as_percentage + "%",
-							max_uses === 0 ? "Unlimited" : max_uses
+							max_uses === 0 ? "Unlimited" : available
 						];
 
 						const active = activeCodeId === id && showCodeDialog;


### PR DESCRIPTION
This fixes the following issues:
- The availability was not being calculated correctly for the list of codes in the event dashboard table
- The max_per_user field was not being saved or populated in the admin dialog

Requires https://github.com/big-neon/bn-api/pull/1181