### PR TITLE
Format cents as dollars

### DIFF
--- a/src/components/pages/events/TicketSelection.js
+++ b/src/components/pages/events/TicketSelection.js
@@ -104,7 +104,7 @@ class TicketSelection extends Component {
 		if (discount_as_percentage) {
 			discount_message = discount_as_percentage + "% Discount applied";
 		} else if (discount_in_cents){
-			discount_message = "$" + discount_in_cents + " Discount applied";
+			discount_message = dollars(discount_in_cents) + " Discount applied";
 		}
 		return (
 			<div>


### PR DESCRIPTION
Fix an error where cents were not formatted as dollars.