### PR TITLE
Fix Box Office bug when adding holds for private ticket types

### DIFF
--- a/src/components/pages/boxoffice/sales/Index.js
+++ b/src/components/pages/boxoffice/sales/Index.js
@@ -250,9 +250,7 @@ class TicketSales extends Component {
 				const { ticket_type_id, discount_in_cents, hold_type } = holds[id];
 
 				totalNumberSelected = totalNumberSelected + selectedHolds[id];
-				console.log("tt_id", ticket_type_id);
-				console.log("tt: ", ticketTypes);
-				console.log("tt[id]", ticketTypes[ticket_type_id]);
+
 				if (hold_type !== "Comp") {
 					const { ticket_pricing } = ticketTypes[ticket_type_id];
 					const { price_in_cents } = ticket_pricing;

--- a/src/components/pages/boxoffice/sales/Index.js
+++ b/src/components/pages/boxoffice/sales/Index.js
@@ -122,7 +122,7 @@ class TicketSales extends Component {
 		}
 
 		return ticketTypeIds.map(id => {
-			const { name, available, ticket_pricing, ...rest } = ticketTypes[id];
+			const { name, available, ticket_pricing, hidden,  ...rest } = ticketTypes[id];
 
 			let disabled = false;
 			let price_in_cents = 0;
@@ -130,6 +130,10 @@ class TicketSales extends Component {
 				price_in_cents = ticket_pricing.price_in_cents;
 			} else {
 				disabled = true; //No pricing yet so ticket probably not available for sale yet
+			}
+
+			if (hidden) {
+				return null;
 			}
 
 			return (
@@ -222,7 +226,7 @@ class TicketSales extends Component {
 
 		const { ticketTypes, holds } = boxOffice;
 
-		if (!ticketTypes || Object.keys(ticketTypes).length < 1) {
+		if ((!ticketTypes || Object.keys(ticketTypes).length < 1) && !holds) {
 			return null;
 		}
 
@@ -246,7 +250,9 @@ class TicketSales extends Component {
 				const { ticket_type_id, discount_in_cents, hold_type } = holds[id];
 
 				totalNumberSelected = totalNumberSelected + selectedHolds[id];
-
+				console.log("tt_id", ticket_type_id);
+				console.log("tt: ", ticketTypes);
+				console.log("tt[id]", ticketTypes[ticket_type_id]);
 				if (hold_type !== "Comp") {
 					const { ticket_pricing } = ticketTypes[ticket_type_id];
 					const { price_in_cents } = ticket_pricing;

--- a/src/stores/boxOffice.js
+++ b/src/stores/boxOffice.js
@@ -109,9 +109,9 @@ class BoxOffice {
 							.redemptionCodes.read({ code: hold.redemption_code })
 							.then(
 								response => {
-									const {data} = response;
+									const { data } = response;
 									if (data.ticket_types && data.ticket_types.length == 1) {
-										const ticketType = {hidden: true, ...data.ticket_types[0]};
+										const ticketType = { hidden: true, ...data.ticket_types[0] };
 										this.ticketTypes[data.ticket_types[0].id] = ticketType;
 									}
 								}

--- a/src/stores/boxOffice.js
+++ b/src/stores/boxOffice.js
@@ -58,7 +58,6 @@ class BoxOffice {
 	@action
 	refreshEventTickets() {
 		this.refreshTicketTypes();
-		this.refreshHolds();
 		this.refreshGuests();
 	}
 
@@ -72,13 +71,13 @@ class BoxOffice {
 			.events.read({ id: this.activeEventId })
 			.then(response => {
 				const { ticket_types } = response.data;
-
 				const ticketTypes = {};
 				ticket_types.forEach(({ id, ...ticket_type }) => {
 					ticketTypes[id] = ticket_type;
 				});
-
 				this.ticketTypes = ticketTypes;
+
+				this.refreshHolds();
 			})
 			.catch(error => {
 				console.error(error);
@@ -87,6 +86,7 @@ class BoxOffice {
 					defaultMessage: "Loading event ticket types failed."
 				});
 			});
+
 	}
 
 	@action
@@ -99,10 +99,25 @@ class BoxOffice {
 			.events.holds.index({ event_id: this.activeEventId })
 			.then(response => {
 				const { data } = response.data;
-
 				const holds = {};
 				data.forEach(({ id, ...hold }) => {
 					holds[id] = hold;
+					//Check if the ticket type exists in the ticket type list
+					//if it doesn't then add it to the list marking it as hidden.
+					if (Object.keys(this.ticketTypes).filter(tt => tt === hold.ticket_type_id).length === 0) {
+						Bigneon()
+							.redemptionCodes.read({ code: hold.redemption_code })
+							.then(
+								response => {
+									const {data} = response;
+									if (data.ticket_types && data.ticket_types.length == 1) {
+										const ticketType = {hidden: true, ...data.ticket_types[0]};
+										this.ticketTypes[data.ticket_types[0].id] = ticketType;
+									}
+								}
+							);
+					}
+
 				});
 				
 				this.holds = holds;


### PR DESCRIPTION
### Closes Issues:
Closes https://github.com/big-neon/bigneon/issues/69
### Description:
In the box office if you had a hold on a ticket type marked as private it wouldn't show the bottom checkout bar AND if you added tickets from that hold to the cart it would crash the box office.
### Environment Variables

### Release Video Link:
