### PR TITLE
Default ticket type start date to start of hour

### DIFF
--- a/src/stores/eventUpdate.js
+++ b/src/stores/eventUpdate.js
@@ -123,9 +123,8 @@ class EventUpdate {
 	addTicketType() {
 		//const endDate = this.event.eventDate ? this.event.eventDate : new Date(); //FIXME this will most certainly not work. If a user changes the event date this first ticket type date needs to change.
 		const ticketTypes = this.ticketTypes;
-		const startDate = moment().set({
-			hour: 12,
-			minute: 30,
+		const startDate = moment().tz("America/Los_Angeles").set({
+			minute: 0,
 			second: 0,
 			millisecond: 0
 		});

--- a/src/stores/eventUpdate.js
+++ b/src/stores/eventUpdate.js
@@ -123,7 +123,7 @@ class EventUpdate {
 	addTicketType() {
 		//const endDate = this.event.eventDate ? this.event.eventDate : new Date(); //FIXME this will most certainly not work. If a user changes the event date this first ticket type date needs to change.
 		const ticketTypes = this.ticketTypes;
-		const startDate = moment().tz("America/Los_Angeles").set({
+		const startDate = moment().set({
 			minute: 0,
 			second: 0,
 			millisecond: 0
@@ -145,7 +145,7 @@ class EventUpdate {
 			...updateTimezonesInObjects(
 				{ startDate, startTime: startDate, endDate },
 				this.timezone,
-				true
+				false
 			)
 		};
 


### PR DESCRIPTION
### Closes Issues:
Closes: #1350

### Description:
The associated issue detailed a bug where the default ticket type start date was always set to 12:30 PM PDT. The goal was to have this date be instead set to 'Now' as the 12:30 was a bit random. I have it use the beginning of the current hour and convert it to PDT (since moment uses the local timezone and the web form is PDT labeled).

Note: This change also affects the unpublished events but it's the same behavior as it used to be just with the current date set in place of 12:30 PM PDT that day. We force a start_date for any ticket type that isn't the parent to other ones so a date is currently required by the backend even for ticket types belonging to unpublished events (we could always change this in the future though).

Not sure if the beginning of the hour is ideal so can adjust as needed (should be quick since I know where this is being pulled from now).

### Environment Variables
 * No change

### Release Video Link:
