### PR TITLE
Event Dashboard: Fix held inventory count displayed

### DIFF
--- a/src/components/pages/admin/events/List.js
+++ b/src/components/pages/admin/events/List.js
@@ -220,7 +220,9 @@ class EventsList extends Component {
 				);
 
 				const { timezone } = venue;
-				const isPublished = moment.utc(event.publish_date).isBefore(moment.utc());
+				const isPublished = moment
+					.utc(event.publish_date)
+					.isBefore(moment.utc());
 
 				return (
 					<Grid key={id} item xs={12} sm={12} lg={12}>
@@ -234,10 +236,12 @@ class EventsList extends Component {
 							eventDate={moment.utc(event.event_start).tz(timezone)}
 							menuButton={MenuButton}
 							isPublished={isPublished}
-							isOnSale={isPublished && moment.utc(event.on_sale).isBefore(moment.utc())}
+							isOnSale={
+								isPublished && moment.utc(event.on_sale).isBefore(moment.utc())
+							}
 							totalSold={event.sold_held + event.sold_unreserved}
 							totalOpen={event.tickets_open}
-							totalHeld={event.tickets_held}
+							totalHeld={event.tickets_held - event.sold_held}
 							totalCapacity={event.total_tickets}
 							totalSalesInCents={event.sales_total_in_cents}
 							isExpanded={expandedCardId === id}


### PR DESCRIPTION
### Closes Issues:
Closes: #1373 

### Description:
The inventory held count on the dashboard is incorrect. We provide two numbers via the API the quantity of the total held inventory and the quantity of sold held inventory. Previously the logic always displayed the total held inventory regardless of quantity sold. 

#### Examples

DB values showing total, unsold, and sold quantities:
![Screen Shot 2019-04-22 at 9 46 45 AM](https://user-images.githubusercontent.com/1319304/56503616-f7d81c80-64e3-11e9-8792-5f39586910e3.png)

Ticket types listing showing correct value:
![Screen Shot 2019-04-22 at 9 46 20 AM](https://user-images.githubusercontent.com/1319304/56503614-f7d81c80-64e3-11e9-8c4b-e3aa640372fc.png)

Before modification:
![Screen Shot 2019-04-22 at 9 46 38 AM](https://user-images.githubusercontent.com/1319304/56503615-f7d81c80-64e3-11e9-9420-389ad5ddf19a.png)

After modification:
![Screen Shot 2019-04-22 at 9 46 03 AM](https://user-images.githubusercontent.com/1319304/56503613-f7d81c80-64e3-11e9-9300-408be6b1cc11.png)

### Environment Variables
 * No change

### Release Video Link:
