### PR TITLE
Event Create: Auto select venue if only 1 private available

### DIFF
--- a/src/components/pages/admin/events/updateSections/Details.js
+++ b/src/components/pages/admin/events/updateSections/Details.js
@@ -324,12 +324,13 @@ class Details extends Component {
 		let label = "";
 
 		if (venues !== null) {
+			const privateVenues = venues.filter(v => v.is_private);
 			venues.forEach(venue => {
 				venueOptions.push({ value: venue.id, label: venue.name });
 			});
 
-			if (venues.length == 1) {
-				venueId = venueId || venues[0].id;
+			if (privateVenues.length == 1) {
+				venueId = venueId || privateVenues[0].id;
 			}
 			label = "Venue *";
 		} else {


### PR DESCRIPTION
### Closes Issues:
Closes: #1389 
Relates to: #1411

### Description:
Further adjustments to this logic to auto select if there is only 1 private venue available. In the original pull request I mentioned how we'd only be able to use this up until we made some public venues as the issue mentioned selecting it if only one was available. @Krakaw mentioned in that PR that we could still use this logic for organizations that have only one private venue. I've adjusted the logic here in place of checking for only one available venue to check for only one private venue per that comment. 

Added Keith for review just to make sure that was the intent here but makes sense especially for smaller organizations.

### Environment Variables
 * No change

### API requirements

### Release Video Link:
