### PR TITLE
Fix issue with download CSV and large datasets

### DIFF
--- a/src/helpers/downloadCSV.js
+++ b/src/helpers/downloadCSV.js
@@ -5,9 +5,10 @@ export default (rows, name = "data") => {
 		csvContent += `"${row}"\r\n`;
 	});
 
-	const encodedUri = encodeURI(csvContent);
+	const blob = new Blob([csvContent], { type: "text/csv" });
+	const href = window.URL.createObjectURL(blob);
 	const link = document.createElement("a");
-	link.setAttribute("href", encodedUri);
+	link.setAttribute("href", href);
 
 	const timeStamp = Math.floor(Date.now() / 1000);
 	link.setAttribute("download", `${name}_${timeStamp}.csv`);


### PR DESCRIPTION
### Closes Issues:
Closes: #1441

### Description:
This pull request closes the associated issue by changing the way we handle CSVs in the app to use blobs. Previously the app would fail with a network error for larger datasets (I experienced it locally with a dataset of 116800 rows) but after the fix I no longer see that issue.

I tested this by using Mike's PR (https://github.com/big-neon/bn-api/pull/1275) which introduces a new mocha test that bulk creates orders. Unfortunately it uses Stripe so it's rather slow so I stopped it midway through and instead edited the `src/helpers/downloadCSV.js` file to loop over the rows it adds 800 additional times creating a massive CSV.

### Environment Variables
 * No change

### API requirements

### Release Video Link:
