### PR TITLE
Fix issue with CSV export including invalid row

### DIFF
--- a/src/helpers/downloadCSV.js
+++ b/src/helpers/downloadCSV.js
@@ -1,5 +1,5 @@
 export default (rows, name = "data") => {
-	let csvContent = "data:text/csv;charset=utf-8,";
+	let csvContent = "";
 	rows.forEach(rowArray => {
 		const row = rowArray.join(`","`);
 		csvContent += `"${row}"\r\n`;


### PR DESCRIPTION
### Closes Issues:
Closes #1468

### Description:
Fixes a mistake I introduced with #1441 that I missed while testing given I was using dummy data to create a larger CSV. The line was needed with the old approach but is included in the CSV itself with the new.

### Environment Variables
 * No change

### API requirements

### Release Video Link:
