### PR TITLE
[DNM] Fix multiple row issue for report

### DIFF
--- a/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
+++ b/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
@@ -16,48 +16,6 @@ import reportDateRangeHeading from "../../../../../helpers/reportDateRangeHeadin
 import user from "../../../../../stores/user";
 import { observer } from "mobx-react";
 
-//Temp solution to group price points if they have the same name and price
-//If the API performs this function in the future, this code can be removed
-//Iterates through price points and merges number values for price points that have the same pricing_name and price_in_cents
-const groupPricePointsByNameAndPrice = data => {
-	Object.keys(data).forEach(ticket_type_id => {
-		const ticketType = data[ticket_type_id];
-		const { pricePoints } = ticketType;
-		const mergedPricePoints = [];
-
-		pricePoints.forEach(pricePoint => {
-			let existingIndex = -1;
-			mergedPricePoints.forEach((mergedPoint, index) => {
-				if (
-					mergedPoint.pricing_name === pricePoint.pricing_name &&
-					mergedPoint.price_in_cents === pricePoint.price_in_cents &&
-					mergedPoint.hold_id === pricePoint.hold_id
-				) {
-					existingIndex = index;
-				}
-			});
-
-			if (existingIndex < 0) {
-				mergedPricePoints.push(pricePoint);
-			} else {
-				//Merge results
-				Object.keys(pricePoint).forEach(pricePointKey => {
-					const pricePointValue = pricePoint[pricePointKey];
-					if (pricePointKey !== "price_in_cents" && !isNaN(pricePointValue)) {
-						//Add it up
-						mergedPricePoints[existingIndex][pricePointKey] =
-							mergedPricePoints[existingIndex][pricePointKey] + pricePointValue;
-					}
-				});
-			}
-		});
-
-		data[ticket_type_id].pricePoints = mergedPricePoints;
-	});
-
-	return data;
-};
-
 export const eventSummaryData = (queryParams, onSuccess, onError) => {
 	//TODO can probably use ticket count report
 	Bigneon()
@@ -173,8 +131,8 @@ export const eventSummaryData = (queryParams, onSuccess, onError) => {
 			}
 
 			onSuccess({
-				eventSales: groupPricePointsByNameAndPrice(eventSales),
-				revenueShare: groupPricePointsByNameAndPrice(revenueShare),
+				eventSales,
+				revenueShare,
 				salesTotals,
 				revenueTotals,
 				otherFees


### PR DESCRIPTION
### Closes Issues:
Closes: #1471 
Related to / needs: https://github.com/big-neon/bn-api/pull/1286

### Description:
This pull request removes a temp fix that was in place for grouping the event summary audit report by the ticket pricing name, price in favor of the api doing it directly.

Note below the total face being wrong is known and a fix is ready but waiting on hearing back here before I push it up: https://github.com/big-neon/bn-web/issues/1417

Pre API and web modifications:
![Screen Shot 2019-05-22 at 5 00 28 PM](https://user-images.githubusercontent.com/1319304/58210056-4e3ca480-7cb6-11e9-8f23-f60b591847ad.png)

With web change but no API change (reverts the temp fix):
![Screen Shot 2019-05-22 at 4 58 10 PM](https://user-images.githubusercontent.com/1319304/58210053-4e3ca480-7cb6-11e9-9ea5-d3cf66402007.png)

With both:
![Screen Shot 2019-05-22 at 4 45 29 PM](https://user-images.githubusercontent.com/1319304/58210200-c0ad8480-7cb6-11e9-8dda-68a85bbd1c8a.png)


### Environment Variables
 * No change

### API requirements

### Release Video Link:
