### PR TITLE
Search guest list by full name

### DIFF
--- a/src/components/pages/boxoffice/guests/Index.js
+++ b/src/components/pages/boxoffice/guests/Index.js
@@ -111,13 +111,11 @@ class GuestList extends Component {
 
 			if (
 				this.stringContainedInArray(
-					[
-						first_name,
-						last_name,
-						[first_name, last_name].join(" "),
-						...ticketIds
-					],
+					[first_name, last_name, ...ticketIds],
 					searchQuery
+				) ||
+				RegExp(searchQuery.replace(" ", ".*"), "gi").test(
+					[first_name, last_name].join(" ")
 				)
 			) {
 				filteredGuests[user_id] = guests[user_id];

--- a/src/components/pages/boxoffice/guests/Index.js
+++ b/src/components/pages/boxoffice/guests/Index.js
@@ -111,7 +111,12 @@ class GuestList extends Component {
 
 			if (
 				this.stringContainedInArray(
-					[first_name, last_name, ...ticketIds],
+					[
+						first_name,
+						last_name,
+						[first_name, last_name].join(" "),
+						...ticketIds
+					],
 					searchQuery
 				)
 			) {

--- a/src/components/pages/boxoffice/guests/Index.js
+++ b/src/components/pages/boxoffice/guests/Index.js
@@ -110,10 +110,7 @@ class GuestList extends Component {
 			});
 
 			if (
-				this.stringContainedInArray(
-					[first_name, last_name, ...ticketIds],
-					searchQuery
-				) ||
+				this.stringContainedInArray(ticketIds, searchQuery) ||
 				RegExp(searchQuery.replace(" ", ".*"), "gi").test(
 					[first_name, last_name].join(" ")
 				)


### PR DESCRIPTION
### Closes Issues:
Closes: #1473

### Description:
The associated issue mentioned how the guest list search for the web was not working for the full name. It appears that it does not hit the API using the query but instead does a local search. Guessing this is being done for speed purposes? I tried locally to switch to use the API instead but it really slowed the app down considerably. May be something we want to iterate on and just make this temp change to append the full name to the list of search criteria. 

@Jasonvdb just a heads up re: the API query not in use here. Edit: filed #1479

![Screen Shot 2019-05-23 at 2 36 59 PM](https://user-images.githubusercontent.com/1319304/58277674-48070080-7d68-11e9-8166-378ef6d83762.png)

![Screen Shot 2019-05-23 at 3 49 47 PM](https://user-images.githubusercontent.com/1319304/58282230-1fd0cf00-7d73-11e9-8d11-e146b3b71b20.png)


### Environment Variables
 * No change

### API requirements

### Release Video Link:
