### PR TITLE
Adjust search to allow for last name prior to first name

### DIFF
--- a/src/components/pages/boxoffice/guests/Index.js
+++ b/src/components/pages/boxoffice/guests/Index.js
@@ -109,11 +109,17 @@ class GuestList extends Component {
 				ticketIds.push(id);
 			});
 
+			const name_regex = RegExp(
+				searchQuery
+					.toLowerCase()
+					.replace(/\s+|,/g, "")
+					.split("")
+					.join(".*?")
+			);
 			if (
 				this.stringContainedInArray(ticketIds, searchQuery) ||
-				RegExp(searchQuery.replace(" ", ".*"), "gi").test(
-					[first_name, last_name].join(" ")
-				)
+				name_regex.test([first_name, last_name].join(" ").toLowerCase()) ||
+				name_regex.test([last_name, first_name].join(" ").toLowerCase())
 			) {
 				filteredGuests[user_id] = guests[user_id];
 			}


### PR DESCRIPTION
### References Issues:
References: #1473

### Description:
This adds support for searching by last name prior to first. It wasn't in the original acceptance criteria for the parent issue https://github.com/big-neon/bigneon/issues/165 but may have value in countries where last name generally is written prior to first like Japan as it may feel more natural to search that way. I also ignore the commas in the search query in case people try to emulate the names written below now that we support last name first.

![Screen Shot 2019-06-03 at 7 32 54 AM](https://user-images.githubusercontent.com/1319304/58799145-77bcd080-85d2-11e9-91c7-cef2be724b57.png)
![Screen Shot 2019-06-03 at 7 33 09 AM](https://user-images.githubusercontent.com/1319304/58799146-77bcd080-85d2-11e9-82b9-caa6064f5209.png)
![Screen Shot 2019-06-03 at 7 33 16 AM](https://user-images.githubusercontent.com/1319304/58799147-77bcd080-85d2-11e9-9463-e83af8542097.png)


### Environment Variables
 * No change

### API requirements

### Release Video Link:
