### PR TITLE
[DNM] Event audit report: Fix face calculation

### DIFF
--- a/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
+++ b/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
@@ -38,10 +38,7 @@ export const eventSummaryData = (queryParams, onSuccess, onError) => {
 			sales.forEach(sale => {
 				const { ticket_type_id } = sale;
 
-				const total_face_value_in_cents =
-					sale.total_gross_income_in_cents -
-					sale.total_client_fee_in_cents -
-					sale.total_company_fee_in_cents;
+				const total_face_value_in_cents = sale.total_gross_income_in_cents;
 
 				if (!eventSales[ticket_type_id]) {
 					eventSales[ticket_type_id] = {
@@ -51,7 +48,6 @@ export const eventSummaryData = (queryParams, onSuccess, onError) => {
 							online_count: sale.online_count,
 							box_office_count: sale.box_office_count,
 							comp_count: sale.comp_count,
-							total_gross_income_in_cents: sale.total_gross_income_in_cents,
 							total_face_value_in_cents,
 							total_sold: sale.total_sold
 						}
@@ -62,8 +58,6 @@ export const eventSummaryData = (queryParams, onSuccess, onError) => {
 					totals.box_office_count += sale.box_office_count;
 					totals.total_sold += sale.total_sold;
 					totals.comp_count += sale.comp_count;
-					totals.total_gross_income_in_cents +=
-						sale.total_gross_income_in_cents;
 					totals.total_face_value_in_cents += total_face_value_in_cents;
 
 					eventSales[ticket_type_id].pricePoints.push({


### PR DESCRIPTION
### References Issues:
References: #1417 

### Description:
This branch fixes the associated issue by modifying how the face price is calculated. Face price isn't the ticket pricing for the base pricing but rather the discount inclusive fee inclusive price (I believe? Confirming via https://github.com/big-neon/bn-web/issues/1417#issuecomment-498387220).

Since the face price includes the fees I've removed the subtraction of the fees from the totaling. The face column data will be off until https://github.com/big-neon/bn-api/pull/1311 has been merged as well as it fixes an issue with the face price returned.

DNM as we're still confirming whether or not this is the correct calculation.

 ### Examples
Ticket costing $30 with $0.10 inclusive fees per ticket and $1.00 order fee:
![Screen Shot 2019-06-04 at 1 42 06 PM](https://user-images.githubusercontent.com/1319304/58901449-378f4800-86cf-11e9-931e-379ff10c9786.png)
![Screen Shot 2019-06-04 at 1 42 18 PM](https://user-images.githubusercontent.com/1319304/58901450-378f4800-86cf-11e9-86ec-f0ac7d8e19e3.png)
![Screen Shot 2019-06-04 at 1 43 40 PM](https://user-images.githubusercontent.com/1319304/58901452-378f4800-86cf-11e9-93d0-f347375a673e.png)

And for the various discounts, comps etc:
![Screen Shot 2019-06-04 at 1 41 42 PM](https://user-images.githubusercontent.com/1319304/58901448-378f4800-86cf-11e9-9819-716f7a0a5306.png)

### Environment Variables
 * No change

### API requirements

### Release Video Link:
