### PR TITLE
Box office hold crash fix

### DIFF
--- a/src/components/pages/boxoffice/sales/Index.js
+++ b/src/components/pages/boxoffice/sales/Index.js
@@ -279,9 +279,18 @@ class TicketSales extends Component {
 				totalNumberSelected = totalNumberSelected + selectedHolds[id];
 
 				if (hold_type !== "Comp") {
-					const { ticket_pricing } = ticketTypes[ticket_type_id];
-					const { price_in_cents } = ticket_pricing;
-					const discountedPrice = price_in_cents - discount_in_cents;
+					let discountedPrice = 0;
+					if (ticketTypes[ticket_type_id]) {
+						const { ticket_pricing } = ticketTypes[ticket_type_id];
+						const { price_in_cents } = ticket_pricing;
+						discountedPrice = price_in_cents - discount_in_cents;
+					} else {
+						//If we don't get the ticket type details in the request because they shouldn't be visible to the users
+						//we have the required fields in the holds obj
+						const { price_in_cents, discount_in_cents } = holds[id];
+						discountedPrice = price_in_cents - discount_in_cents;
+					}
+
 					totalInCents = totalInCents + discountedPrice * selectedHolds[id];
 				}
 			}


### PR DESCRIPTION
### References Issues:
https://github.com/big-neon/bigneon/issues/186

### Description:
Fixes a crash in the box office for bn-web when a ticket type is unavailable and not visible on the frontend but adding a hold references the price for the missing ticket type.

If we don't receive the ticket type details, rather use the price provided in the hold.

### Environment Variables
 * No change

### API requirements

### Release Video Link:
