### PR TITLE
Hide actions when a ticket has been redeemed

### DIFF
--- a/src/components/pages/myevents/EventTicketsCard.js
+++ b/src/components/pages/myevents/EventTicketsCard.js
@@ -283,7 +283,7 @@ class EventTicketsCard extends Component {
 					}
 
 					//Default action buttons
-					if (showActions && !actionCol) {
+					if (showActions && !actionCol && !disabled) {
 						actionCol = (
 							<Typography className={classes.ticketDetailsText}>
 								<StyledLink underlined onClick={() => onTicketSelect(ticket)}>


### PR DESCRIPTION
### References Issues:
Connected to #1638 
### Description:
When a ticket has been redeemed hide the show qr and transfer actions
### Environment Variables
 * No change

### API requirements

### Release Video Link:
![image](https://user-images.githubusercontent.com/41575888/61698851-185d8000-ad3a-11e9-9c46-f042377c25fa.png)
