### PR TITLE
Adding timezone display for event show times on event view page

### DIFF
--- a/src/stores/selectedEvent.js
+++ b/src/stores/selectedEvent.js
@@ -107,7 +107,7 @@ class SelectedEvent {
 					.format("h:mm A");
 				const displayShowTime = moment(eventStartDateMoment)
 					.tz(venueTimezone)
-					.format("h:mm A");
+					.format("h:mm A z");
 
 				this.event = {
 					...event,


### PR DESCRIPTION
### References Issues:
https://github.com/big-neon/bigneon/issues/174#issuecomment-514299045

### Description:
Just adding timezone to the event time that's displayed

### Environment Variables
 * No change

### API requirements

### Release Video Link:
