### PR TITLE
Added checks and displays for cancelled events

### DIFF
--- a/src/components/pages/events/CheckoutConfirmation.js
+++ b/src/components/pages/events/CheckoutConfirmation.js
@@ -350,6 +350,7 @@ class CheckoutConfirmation extends Component {
 		const { cartSummary, formattedExpiryTime, cartExpired } = cart;
 
 		const { event, artists, id, venue } = selectedEvent;
+		const eventIsCancelled = !!(event && event.cancelled_at);
 
 		if (event === null) {
 			return (
@@ -409,6 +410,7 @@ class CheckoutConfirmation extends Component {
 							/>
 						) : (
 							<Button
+								disabled={eventIsCancelled}
 								variant="callToAction"
 								style={{ width: "100%" }}
 								onClick={this.onFreeCheckout.bind(this)}

--- a/src/components/pages/events/CheckoutSelection.js
+++ b/src/components/pages/events/CheckoutSelection.js
@@ -391,11 +391,13 @@ class CheckoutSelection extends Component {
 	}
 
 	renderTicketPricing() {
-		const { ticket_types } = selectedEvent;
+		const { event, ticket_types } = selectedEvent;
 		const { ticketSelection, errors } = this.state;
 		if (!ticket_types) {
 			return <Loader>Loading tickets...</Loader>;
 		}
+
+		const eventIsCancelled = !!(event && event.cancelled_at);
 
 		const ticketTypeRendered = ticket_types
 			.map(ticketType => {
@@ -458,6 +460,7 @@ class CheckoutSelection extends Component {
 						}
 						validateFields={this.validateFields.bind(this)}
 						status={status}
+						eventIsCancelled={eventIsCancelled}
 					/>
 				);
 			})
@@ -474,6 +477,7 @@ class CheckoutSelection extends Component {
 		const { isSubmitting, isSubmittingPromo, ticketSelection } = this.state;
 
 		const { event, venue, artists, organization, id } = selectedEvent;
+		const eventIsCancelled = !!(event && event.cancelled_at);
 
 		if (event === null) {
 			return (
@@ -553,13 +557,17 @@ class CheckoutSelection extends Component {
 					/>
 
 					<Button
-						disabled={isSubmitting}
+						disabled={isSubmitting || eventIsCancelled}
 						onClick={() => this.onSubmit()}
 						size="large"
 						style={{ width: "100%" }}
 						variant="callToAction"
 					>
-						{isSubmitting ? "Adding..." : "Continue"}
+						{isSubmitting
+							? "Adding..."
+							: eventIsCancelled
+								? "Cancelled"
+								: "Continue"}
 					</Button>
 				</div>
 			);
@@ -580,7 +588,10 @@ class CheckoutSelection extends Component {
 						containerClass={classes.desktopContent}
 						containerStyle={{ minHeight: overlayCardHeightAdjustment }}
 						col1={(
-							<EventDescriptionBody artists={artists}>
+							<EventDescriptionBody
+								eventIsCancelled={eventIsCancelled}
+								artists={artists}
+							>
 								{additional_info}
 							</EventDescriptionBody>
 						)}

--- a/src/components/pages/events/EventDescriptionBody.js
+++ b/src/components/pages/events/EventDescriptionBody.js
@@ -7,6 +7,7 @@ import Typography from "@material-ui/core/Typography";
 import nl2br from "../../../helpers/nl2br";
 import { textColorPrimary } from "../../../config/theme";
 import ArtistSummary from "../../elements/event/ArtistSummary";
+import { Link } from "react-router-dom";
 
 const styles = theme => ({
 	root: {
@@ -31,10 +32,16 @@ const styles = theme => ({
 });
 
 const EventDescriptionBody = props => {
-	const { classes, children, artists } = props;
+	const { classes, children, artists, eventIsCancelled } = props;
 
 	return (
 		<div className={classes.root}>
+			{eventIsCancelled ? (
+				<div>
+					Sorry, this event is no longer available.{" "}
+					<Link to={"/"}>Browse other events</Link>
+				</div>
+			) : null}
 			{children ? (
 				<Typography className={classes.eventDetailText}>
 					{nl2br(children)}
@@ -42,17 +49,16 @@ const EventDescriptionBody = props => {
 			) : null}
 
 			{artists && artists.length !== 0 ? (
-				<Grid className={classes.artistsContainer} spacing={32} container direction="row" justify="flex-start" alignItems="flex-start">
+				<Grid
+					className={classes.artistsContainer}
+					spacing={32}
+					container
+					direction="row"
+					justify="flex-start"
+					alignItems="flex-start"
+				>
 					{artists.map(({ artist, importance }, index) => (
-						<Grid
-							item
-							xs={12}
-							sm={12}
-							md={12}
-							lg={6}
-							xl={6}
-							key={index}
-						>
+						<Grid item xs={12} sm={12} md={12} lg={6} xl={6} key={index}>
 							<ArtistSummary headliner={importance === 0} {...artist}/>
 						</Grid>
 					))}
@@ -62,14 +68,13 @@ const EventDescriptionBody = props => {
 	);
 };
 
-EventDescriptionBody.defaultProps = {
-
-};
+EventDescriptionBody.defaultProps = {};
 
 EventDescriptionBody.propTypes = {
 	classes: PropTypes.object.isRequired,
 	children: PropTypes.string,
-	artists: PropTypes.array
+	artists: PropTypes.array,
+	eventIsCancelled: PropTypes.bool
 };
 
 export default withStyles(styles)(EventDescriptionBody);

--- a/src/components/pages/events/TicketSelection.js
+++ b/src/components/pages/events/TicketSelection.js
@@ -99,9 +99,10 @@ class TicketSelection extends Component {
 			discount_in_cents,
 			discount_as_percentage,
 			redemption_code,
-			status
+			eventIsCancelled
 		} = this.props;
-
+		let { status } = this.props;
+		status = eventIsCancelled ? "Cancelled" : status;
 		const { showDescription } = this.state;
 
 		// const incrementText =
@@ -292,7 +293,8 @@ TicketSelection.propTypes = {
 	validateFields: PropTypes.func.isRequired,
 	limitPerPerson: PropTypes.number,
 	status: PropTypes.string.isRequired,
-	classes: PropTypes.object.isRequired
+	classes: PropTypes.object.isRequired,
+	eventIsCancelled: PropTypes.bool
 };
 
 export default withStyles(styles)(TicketSelection);

--- a/src/components/pages/events/ViewEvent.js
+++ b/src/components/pages/events/ViewEvent.js
@@ -226,6 +226,10 @@ class ViewEvent extends Component {
 		// if (hasAvailableTickets === false && !event.is_external) {
 		// 	return { ctaText: "No available tickets", enabled: false };
 		// }
+		const eventIsCancelled = !!(event && event.cancelled_at);
+		if (eventIsCancelled) {
+			return { ctaText: "Cancelled", enabled: false };
+		}
 
 		switch (event.override_status) {
 			case "PurchaseTickets":
@@ -365,6 +369,7 @@ class ViewEvent extends Component {
 			min_ticket_price,
 			max_ticket_price
 		} = event;
+		const eventIsCancelled = !!(event && event.cancelled_at);
 
 		const promo_image_url = event.promo_image_url
 			? optimizedImageUrl(event.promo_image_url)
@@ -460,7 +465,10 @@ class ViewEvent extends Component {
 						containerClass={classes.desktopContent}
 						containerStyle={{ minHeight: overlayCardHeightAdjustment }}
 						col1={(
-							<EventDescriptionBody artists={artists}>
+							<EventDescriptionBody
+								eventIsCancelled={eventIsCancelled}
+								artists={artists}
+							>
 								{additional_info}
 							</EventDescriptionBody>
 						)}


### PR DESCRIPTION
### References Issues:
Connected to big-neon/bigneon#192
### Description:
If an event is cancelled disable purchase buttons and add a link back to the home page.
### Environment Variables
 * No change

### API requirements

### Release Video Link:
![image](https://user-images.githubusercontent.com/41575888/61862060-80909b00-aecd-11e9-83fc-e2cbda70bca2.png)
![image](https://user-images.githubusercontent.com/41575888/61862072-871f1280-aecd-11e9-962f-bdb69877b319.png)
