### PR TITLE
Added break point to adjust flex value so date doesn't wrap to new line

### DIFF
--- a/src/components/pages/admin/fans/FanActivityCardRow.js
+++ b/src/components/pages/admin/fans/FanActivityCardRow.js
@@ -3,36 +3,52 @@ import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core";
 import classNames from "classnames";
 
-const styles = theme => ({
-	root: {
-		display: "flex",
-		alignItems: "center"
-	},
-	shaded: {
-		backgroundColor: "#F5F7FA",
-		borderRadius: 8
-	},
-	heading: {
-		textTransform: "capitalize"
-	}
-});
+const styles = theme => {
+	return {
+		root: {
+			display: "flex",
+			alignItems: "center"
+		},
+		shaded: {
+			backgroundColor: "#F5F7FA",
+			borderRadius: 8
+		},
+		heading: {
+			textTransform: "capitalize"
+		},
+		col1: {
+			flex: 1,
+			textAlign: "center"
+		},
+		col2: {
+			flex: 3,
+			textAlign: "left",
+			[theme.breakpoints.only("lg")]: {
+				flex: 4
+			}
+		},
+		col4: {
+			flex: 14,
+			textAlign: "left"
+		},
+		col5: {
+			flex: 3,
+			textAlign: "right"
+		}
+	};
+};
 
 const FanActivityCardRow = props => {
 	const { heading, children, shaded, classes } = props;
 
-	const columnStyles = [
-		{ flex: 1, textAlign: "center" },
-		{ flex: 3, textAlign: "left" },
-		{ flex: 14, textAlign: "left" },
-		{ flex: 3, textAlign: "right" }
-	];
-
 	const columns = children.map((child, index) => {
 		return (
 			<span
-				className={classNames({ [classes.heading]: heading })}
+				className={classNames({
+					[classes.heading]: heading,
+					[classes[`col${index}`]]: true
+				})}
 				key={index}
-				style={columnStyles[index]}
 			>
 				{child}
 			</span>


### PR DESCRIPTION
### References Issues:

### Description:
Date was looking like this:
![Screenshot 2019-07-26 at 10 38 34](https://user-images.githubusercontent.com/5300488/61938729-0d049180-af92-11e9-8d29-b6c75c7074ae.png)

This PR makes it like this for this screen width:
![Screenshot 2019-07-26 at 10 40 27](https://user-images.githubusercontent.com/5300488/61938758-1f7ecb00-af92-11e9-9011-bb4cdec9105d.png)

### Environment Variables
 * No change

### API requirements

### Release Video Link:
