### PR TITLE
Return to the correct event when clicking on the cart

### DIFF
--- a/src/components/common/cart/CartHeaderLink.js
+++ b/src/components/common/cart/CartHeaderLink.js
@@ -28,8 +28,10 @@ const styles = theme => ({
 });
 
 const CartHeaderLink = observer(({ classes }) => {
-	const { ticketCount, formattedExpiryTime, latestEventId } = cart;
-	const eventIdInItems = [...new Set(cart.items.map(item => item.event_id))];
+	const { ticketCount, formattedExpiryTime, latestEventId, items = [] } = cart;
+	const eventIdInItems = [...new Set(items.map(item => item.event_id))].filter(
+		item => !!item
+	);
 
 	const returnEventId = eventIdInItems.length
 		? eventIdInItems[0]

--- a/src/components/common/cart/CartHeaderLink.js
+++ b/src/components/common/cart/CartHeaderLink.js
@@ -29,23 +29,26 @@ const styles = theme => ({
 
 const CartHeaderLink = observer(({ classes }) => {
 	const { ticketCount, formattedExpiryTime, latestEventId } = cart;
+	const eventIdInItems = [...new Set(cart.items.map(item => item.event_id))];
+
+	const returnEventId = eventIdInItems.length
+		? eventIdInItems[0]
+		: latestEventId;
 	if (ticketCount < 1) {
 		return null;
 	}
 
 	//Only if we have an event id can we link to the right checkout page
-	const LinkContainer = latestEventId
+	const LinkContainer = returnEventId
 		? props => <Link {...props}/>
 		: props => <div {...props}/>;
 
 	return (
-		<LinkContainer to={`/events/${latestEventId}/tickets/confirmation`}>
+		<LinkContainer to={`/events/${returnEventId}/tickets/confirmation`}>
 			<Button className={classes.menuButton}>
 				<ShoppingCartIcon className={classes.rightIcon}/>
 				{ticketCount}
-
 				<span className={classes.spacer}/>
-
 				<TimerIcon className={classes.rightIcon}/>
 				<span className={classes.expiryTimeSpan}>{formattedExpiryTime}</span>
 			</Button>


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1135145228458502/1133349072898517
### Description:
If you have navigated to another event the cart would incorrectly take you back to that event when clicking on the cart icon in the menu. This PR uses the event_id in the items list from the cart response to navigate to the correct `events/tickets/confirmation` page
### Release Screenshots / Video:
http://cl.ly/744c807db250
### Environment Variables:
 * No change

# API requirements:
Requires big-neon/bn-api#1454