### PR TITLE
Updated ticket total to be face value (total - fees - discount)

### DIFF
--- a/src/components/pages/admin/events/dashboard/orders/order/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/Index.js
@@ -104,14 +104,14 @@ class SingleOrder extends Component {
 				const platform = is_box_office ? "Box office" : data.platform || "";
 
 				let fees_in_cents = 0;
-				items.forEach(({ item_type, unit_price_in_cents }) => {
+				items.forEach(({ item_type, unit_price_in_cents, quantity }) => {
 					//Only include fee type items
 					if (
 						["CreditCardFees", "PerUnitFees", "CreditCardFees"].indexOf(
 							item_type
 						) > -1
 					) {
-						fees_in_cents += unit_price_in_cents;
+						fees_in_cents += unit_price_in_cents * quantity;
 					}
 				});
 

--- a/src/components/pages/admin/events/dashboard/orders/order/TicketCard.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/TicketCard.js
@@ -87,6 +87,9 @@ const TicketCard = ({
 
 	const showAllDetails = !shortened;
 
+	const ticketFacePriceInCents =
+		total_price_in_cents - fees_price_in_cents + discount_price_in_cents;
+
 	if (ticket_instance_id) {
 		return (
 			<Card className={classes.root}>
@@ -141,7 +144,7 @@ const TicketCard = ({
 						<Typography style={colStyles[4]}>1</Typography>
 					) : null}
 					<Typography style={colStyles[5]}>
-						{dollars(total_price_in_cents - fees_price_in_cents)}
+						{dollars(ticketFacePriceInCents)}
 					</Typography>
 					{showAllDetails ? (
 						<Typography style={colStyles[6]} className={classes.statusText}>


### PR DESCRIPTION
### References Issues:
https://github.com/big-neon/bn-web/issues/1687#issuecomment-520484313

### Description:
Ticket total should be what the user actually paid. 

`total_price_in_cents - fees_price_in_cents + discount_price_in_cents`

### Release Screenshots / Video:
<img width="769" alt="Screenshot 2019-08-15 at 10 12 52" src="https://user-images.githubusercontent.com/5300488/63082221-eeb50480-bf45-11e9-9712-728d57d942be.png">

### Environment Variables:
 * No change

### API requirements:
