### PR TITLE
Auto add quantity rules

### DIFF
--- a/src/components/pages/events/CheckoutSelection.js
+++ b/src/components/pages/events/CheckoutSelection.js
@@ -174,7 +174,7 @@ class CheckoutSelection extends Component {
 			return 0;
 		}
 
-		//If there are less available than the increment they need to buy in
+		//Should first display `Sold out`.
 		if (available < increment) {
 			return 0;
 		}

--- a/src/components/pages/events/CheckoutSelection.js
+++ b/src/components/pages/events/CheckoutSelection.js
@@ -160,6 +160,33 @@ class CheckoutSelection extends Component {
 		}
 	}
 
+	//Determine the amount to auto add to cart based on increment, limit per person and available tickets
+	getAutoAddQuantity(ticketType) {
+		const { increment, limit_per_person, available } = ticketType;
+
+		//If limit_per_person is set don't allow auto selecting more than the user is allowed to buy
+		if (limit_per_person && AUTO_SELECT_TICKET_AMOUNT > limit_per_person) {
+			return limit_per_person;
+		}
+
+		//Will display `Sold out` before it reaches here, but just in case
+		if (available < limit_per_person) {
+			return 0;
+		}
+
+		//If there are less available than the increment they need to buy in
+		if (available < increment) {
+			return 0;
+		}
+
+		//If the default auto select amount is NOT divisible by the increment amount, rather auto select the first increment
+		if (AUTO_SELECT_TICKET_AMOUNT % increment != 0) {
+			return increment;
+		}
+
+		return AUTO_SELECT_TICKET_AMOUNT;
+	}
+
 	setTicketSelectionFromExistingCart(items) {
 		const ticketSelection = {};
 		const { id } = this.props.match.params;
@@ -184,7 +211,7 @@ class CheckoutSelection extends Component {
 
 				if (!ticketSelection[type_id]) {
 					ticketSelection[type_id] = {
-						quantity: AUTO_SELECT_TICKET_AMOUNT
+						quantity: this.getAutoAddQuantity(ticket_types[0])
 					};
 				}
 
@@ -206,10 +233,11 @@ class CheckoutSelection extends Component {
 								}
 								const type_id = types[i].id;
 
+								//Auto add a ticket after refreshing the event tickets
 								if (!ticketSelection[type_id]) {
 									if (types.length === 1) {
 										ticketSelection[type_id] = {
-											quantity: AUTO_SELECT_TICKET_AMOUNT
+											quantity: this.getAutoAddQuantity(types[i])
 										};
 									}
 								}

--- a/src/components/pages/events/CheckoutSelection.js
+++ b/src/components/pages/events/CheckoutSelection.js
@@ -163,28 +163,24 @@ class CheckoutSelection extends Component {
 	//Determine the amount to auto add to cart based on increment, limit per person and available tickets
 	getAutoAddQuantity(ticketType) {
 		const { increment, limit_per_person, available } = ticketType;
-
-		//If limit_per_person is set don't allow auto selecting more than the user is allowed to buy
-		if (limit_per_person && AUTO_SELECT_TICKET_AMOUNT > limit_per_person) {
-			return limit_per_person;
-		}
-
-		//Will display `Sold out` before it reaches here, but just in case
-		if (available < limit_per_person) {
-			return 0;
-		}
-
-		//Should first display `Sold out`.
-		if (available < increment) {
-			return 0;
-		}
+		let quantity = AUTO_SELECT_TICKET_AMOUNT;
 
 		//If the default auto select amount is NOT divisible by the increment amount, rather auto select the first increment
 		if (AUTO_SELECT_TICKET_AMOUNT % increment != 0) {
-			return increment;
+			quantity = increment;
 		}
 
-		return AUTO_SELECT_TICKET_AMOUNT;
+		//If limit_per_person is set don't allow auto selecting more than the user is allowed to buy
+		if (limit_per_person && quantity > limit_per_person) {
+			quantity = limit_per_person;
+		}
+
+		//Will first display `Sold out` for this rule anyways.
+		if (available < increment) {
+			quantity = 0;
+		}
+
+		return quantity;
 	}
 
 	setTicketSelectionFromExistingCart(items) {
@@ -466,12 +462,13 @@ class CheckoutSelection extends Component {
 						key={id}
 						name={name}
 						description={description}
-						available={ticketsAvailable}
+						ticketsAvailable={ticketsAvailable}
 						price_in_cents={price_in_cents}
 						error={errors[id]}
 						amount={ticketSelection[id] ? ticketSelection[id].quantity : 0}
 						increment={increment}
 						limitPerPerson={limitPerPerson}
+						available={available}
 						discount_in_cents={discount_in_cents}
 						discount_as_percentage={discount_as_percentage}
 						redemption_code={redemption_code}

--- a/src/components/pages/events/TicketSelection.js
+++ b/src/components/pages/events/TicketSelection.js
@@ -134,6 +134,12 @@ class TicketSelection extends Component {
 			priceDisplay = `${dollars(calculatedPriceInCents, true)}`;
 		}
 
+		//They can't select more than is available (This will be fixed in the API soon hopefully)
+		if (available < increment) {
+			status = "SoldOut";
+			priceActive = false;
+		}
+
 		let unavailableLabel = null;
 		switch (status) {
 			case "SoldOut":

--- a/src/components/pages/events/TicketSelection.js
+++ b/src/components/pages/events/TicketSelection.js
@@ -85,7 +85,7 @@ class TicketSelection extends Component {
 
 	render() {
 		const {
-			available,
+			ticketsAvailable,
 			classes,
 			error,
 			name,
@@ -93,6 +93,7 @@ class TicketSelection extends Component {
 			price_in_cents,
 			amount,
 			increment,
+			available,
 			onNumberChange,
 			validateFields,
 			limitPerPerson,
@@ -128,7 +129,7 @@ class TicketSelection extends Component {
 			discount_message = dollars(discount_in_cents) + " Discount applied";
 		}
 
-		let priceActive = available;
+		let priceActive = ticketsAvailable;
 		let priceDisplay = null;
 		if (!isNaN(calculatedPriceInCents)) {
 			priceDisplay = `${dollars(calculatedPriceInCents, true)}`;
@@ -286,7 +287,7 @@ class TicketSelection extends Component {
 }
 
 TicketSelection.propTypes = {
-	available: PropTypes.bool,
+	ticketsAvailable: PropTypes.bool,
 	onNumberChange: PropTypes.func.isRequired,
 	name: PropTypes.string.isRequired,
 	description: PropTypes.string,
@@ -296,6 +297,7 @@ TicketSelection.propTypes = {
 	error: PropTypes.string,
 	amount: PropTypes.number,
 	increment: PropTypes.number.isRequired,
+	available: PropTypes.number.isRequired,
 	validateFields: PropTypes.func.isRequired,
 	limitPerPerson: PropTypes.number,
 	status: PropTypes.string.isRequired,


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1135145228458502/1133349072898527

### Description:
New rules for auto selecting a ticket quantity when there is only one ticket type:
- If the default auto select amount is NOT divisible by the increment amount, rather auto select the first increment.
- If `limit_per_person` is set don't allow auto selecting more than the user is allowed to buy
- If `available` < `increment` don't auto select any.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
