### PR TITLE
hasTickets should be true if at least one ticket type is available

### DIFF
--- a/src/stores/selectedEvent.js
+++ b/src/stores/selectedEvent.js
@@ -334,10 +334,7 @@ class SelectedEvent {
 		}
 		let hasTickets = false;
 		this.ticket_types.map(({ ticket_pricing, end_date }) => {
-			const price = "";
-			if (moment.utc().isAfter(moment.utc(end_date))) {
-				hasTickets = false;
-			} else if (ticket_pricing) {
+			if (ticket_pricing && moment.utc().isBefore(moment.utc(end_date))) {
 				hasTickets = true;
 			}
 		});


### PR DESCRIPTION
### References Issues:

### Description:
Fixes a bug causing an event to show no tickets available if the last ticket type checked wasn't available.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
