### PR TITLE
Show FB marketing menu for certain events

### DIFF
--- a/src/components/pages/admin/events/dashboard/Container.js
+++ b/src/components/pages/admin/events/dashboard/Container.js
@@ -664,17 +664,17 @@ class EventDashboardContainer extends Component {
 							) : null}
 
 							{/*TODO add back when Mike wants to work on it*/}
-							{/*{event.is_external ? null : (*/}
-							{/*<Typography className={classes.menuText}>*/}
-							{/*{this.renderMarketingMenu()}*/}
-							{/*<StyledLink*/}
-							{/*underlined={subheading === "marketing"}*/}
-							{/*onClick={this.handleMarketingMenu.bind(this)}*/}
-							{/*>*/}
-							{/*Marketing*/}
-							{/*</StyledLink>*/}
-							{/*</Typography>*/}
-							{/*)}*/}
+							{event.is_external ? null : (
+								<Typography className={classes.menuText}>
+									{this.renderMarketingMenu()}
+									<StyledLink
+										underlined={subheading === "marketing"}
+										onClick={this.handleMarketingMenu.bind(this)}
+									>
+										Marketing
+									</StyledLink>
+								</Typography>
+							)}
 
 							<Hidden smDown>
 								<div className={classes.additionalDesktopMenuContent}>

--- a/src/components/pages/admin/events/dashboard/Container.js
+++ b/src/components/pages/admin/events/dashboard/Container.js
@@ -664,8 +664,8 @@ class EventDashboardContainer extends Component {
 							) : null}
 
 							{!event.is_external &&
-							event.extra_data_admin &&
-							event.extra_data_admin.preview_facebook_enabled ? (
+							event.extra_admin_data &&
+							event.extra_admin_data.preview_facebook_enabled ? (
 									<Typography className={classes.menuText}>
 										{this.renderMarketingMenu()}
 										<StyledLink

--- a/src/components/pages/admin/events/dashboard/Container.js
+++ b/src/components/pages/admin/events/dashboard/Container.js
@@ -663,18 +663,19 @@ class EventDashboardContainer extends Component {
 								</React.Fragment>
 							) : null}
 
-							{/*TODO add back when Mike wants to work on it*/}
-							{event.is_external ? null : (
-								<Typography className={classes.menuText}>
-									{this.renderMarketingMenu()}
-									<StyledLink
-										underlined={subheading === "marketing"}
-										onClick={this.handleMarketingMenu.bind(this)}
-									>
+							{!event.is_external &&
+							event.extra_data_admin &&
+							event.extra_data_admin.preview_facebook_enabled ? (
+									<Typography className={classes.menuText}>
+										{this.renderMarketingMenu()}
+										<StyledLink
+											underlined={subheading === "marketing"}
+											onClick={this.handleMarketingMenu.bind(this)}
+										>
 										Marketing
-									</StyledLink>
-								</Typography>
-							)}
+										</StyledLink>
+									</Typography>
+								) : null}
 
 							<Hidden smDown>
 								<div className={classes.additionalDesktopMenuContent}>

--- a/src/components/pages/admin/events/dashboard/marketing/FacebookEvents.js
+++ b/src/components/pages/admin/events/dashboard/marketing/FacebookEvents.js
@@ -7,6 +7,8 @@ import user from "../../../../../../stores/user";
 import Loader from "../../../../../elements/loaders/Loader";
 import SelectGroup from "../../../../../common/form/SelectGroup";
 import Button from "../../../../../elements/Button";
+import { FacebookButton } from "../../../../authentication/social/FacebookButton";
+import Grid from "@material-ui/core/Grid";
 
 const styles = theme => ({
 	root: {}
@@ -21,7 +23,8 @@ class FacebookEvents extends Component {
 			pages: [],
 			pageId: null,
 			facebookCategory: null,
-			isSubmitting: false
+			isSubmitting: false,
+			isFacebookLinked: false
 		};
 	}
 
@@ -30,9 +33,12 @@ class FacebookEvents extends Component {
 
 		Bigneon()
 			.external.facebook.pages()
-			.then(response => this.setState({ pages: response.data }))
+			.then(response =>
+				this.setState({ pages: response.data, isFacebookLinked: true })
+			)
 			.catch(error => {
 				console.error(error);
+				this.setState({ isFacebookLinked: false });
 			});
 		//If you need event details, use the eventId prop
 		// Bigneon()
@@ -56,33 +62,71 @@ class FacebookEvents extends Component {
 	}
 
 	render() {
-		const { pages, pageId, facebookCategory, isSubmitting } = this.state;
+		const {
+			pages,
+			pageId,
+			facebookCategory,
+			isSubmitting,
+			isFacebookLinked
+		} = this.state;
 
 		return (
 			<div>
-				<SelectGroup
-					items={pages.map(page => ({
-						value: page.id,
-						name: page.name
-					}))}
-					value={pageId}
-					onChange={e => this.setState({ pageId: e.target.value })}
-				/>
+				<Grid container>
+					<Grid item xs={12} sm={6} md={6} lg={6}>
+						<h1>Create Facebook Event</h1>
+						<p>
+							Increase your event's reach by{" "}
+							<strong>creating a Facebook event</strong>. It's easy!
+						</p>
+						{isFacebookLinked ? (
+							<div>
+								<SelectGroup
+									items={pages.map(page => ({
+										value: page.id,
+										name: page.name
+									}))}
+									value={pageId}
+									onChange={e => this.setState({ pageId: e.target.value })}
+								/>
 
-				<SelectGroup
-					items={[{ value: "MUSIC_EVENT", name: "Music Event" }]}
-					value={facebookCategory}
-					onChange={e => this.setState({ facebookCategory: e.target.value })}
-				/>
-				<Button
-					size="large"
-					type="submit"
-					variant="callToAction"
-					onClick={this.onSubmit.bind(this)}
-					disabled={isSubmitting}
-				>
-					Publish
-				</Button>
+								<SelectGroup
+									items={[{ value: "MUSIC_EVENT", name: "Music Event" }]}
+									value={facebookCategory}
+									onChange={e =>
+										this.setState({ facebookCategory: e.target.value })
+									}
+								/>
+								<Button
+									size="large"
+									type="submit"
+									variant="callToAction"
+									onClick={this.onSubmit.bind(this)}
+									disabled={isSubmitting}
+								>
+									Publish
+								</Button>
+							</div>
+						) : (
+							<div>
+								<FacebookButton scopes={["manage_pages", "publish_pages"]}/>
+							</div>
+						)}
+					</Grid>
+					<Grid item xs={12} sm={12} md={6} lg={6}>
+						<h2>Please Note:</h2>
+						<ul>
+							<li>
+								A user with admin priviledges for your Facebook page needs to
+								give Big Neon permission to create the event
+							</li>
+							<li>
+								Don't worry, we won't create the event until you review the
+								settings and tell us to
+							</li>
+						</ul>
+					</Grid>
+				</Grid>
 			</div>
 		);
 	}

--- a/src/components/pages/authentication/social/FacebookButton.js
+++ b/src/components/pages/authentication/social/FacebookButton.js
@@ -148,7 +148,7 @@ class FacebookButtonDisplay extends Component {
 	}
 
 	render() {
-		const { classes, children } = this.props;
+		const { classes, children, scopes } = this.props;
 		const { authenticated, isAuthenticating } = this.state;
 
 		let text = children || "Continue with facebook";
@@ -156,7 +156,7 @@ class FacebookButtonDisplay extends Component {
 		let onClick = () => {
 			this.setState({ isAuthenticating: true });
 			window.FB.login(this.onFBSignIn.bind(this), {
-				scope: "email"
+				scope: scopes.join(",")
 			});
 		};
 
@@ -194,7 +194,12 @@ class FacebookButtonDisplay extends Component {
 FacebookButtonDisplay.propTypes = {
 	classes: PropTypes.object.isRequired,
 	children: PropTypes.string,
-	onSuccess: PropTypes.func.isRequired
+	onSuccess: PropTypes.func.isRequired,
+	scopes: PropTypes.arrayOf(PropTypes.string)
+};
+
+FacebookButtonDisplay.defaultProps = {
+	scopes: ["email"]
 };
 
 export const FacebookButton = withStyles(styles)(FacebookButtonDisplay);


### PR DESCRIPTION
### References Issues:
Requires big-neon/bn-api#1141

### Description:
Show marketing menu for events that have it in the extra_admin_data field. This will be used for the FB App review team to see preview functionality

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
