### PR TITLE
Use the slug url in the metadata

### DIFF
--- a/src/components/pages/events/Meta.js
+++ b/src/components/pages/events/Meta.js
@@ -154,13 +154,14 @@ const Meta = props => {
 		event_start,
 		event_end,
 		ticket_types,
+		slug,
 		...event
 	} = props;
 
 	//TODO use slug when it's ready
 	const landingUrl = Settings().webUrl;
-	const rootEventUrl = `${landingUrl}/events/${id}`;
-	const ticketSelectionUrl = `${rootEventUrl}/tickets`;
+	const slugEventUrl = `${landingUrl}/events/${slug}`;
+	const ticketSelectionUrl = `${slugEventUrl}/tickets`;
 
 	const promoImageUrl = promo_image_url
 		? optimizedImageUrl(promo_image_url)
@@ -178,7 +179,7 @@ const Meta = props => {
 			googleBreadcrumbData = structuredBreadcrumbData(
 				name,
 				landingUrl,
-				rootEventUrl,
+				slugEventUrl,
 				""
 			);
 			break;
@@ -188,7 +189,7 @@ const Meta = props => {
 			googleBreadcrumbData = structuredBreadcrumbData(
 				name,
 				landingUrl,
-				rootEventUrl,
+				slugEventUrl,
 				ticketSelectionUrl
 			);
 
@@ -217,7 +218,7 @@ const Meta = props => {
 				},
 				{
 					property: "og:url",
-					content: rootEventUrl
+					content: slugEventUrl
 				},
 				{
 					property: "og:description",
@@ -251,7 +252,7 @@ const Meta = props => {
 			link={[
 				{
 					rel: "canonical",
-					href: rootEventUrl
+					href: slugEventUrl
 				},
 				{
 					rel: "image_src",


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1136728345391137/1139369806323215
### Description:
Use the slug url instead of the event id
### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
