### PR TITLE
Changing event type to event category

### DIFF
--- a/src/components/pages/admin/events/updateSections/Details.js
+++ b/src/components/pages/admin/events/updateSections/Details.js
@@ -64,7 +64,7 @@ const validateFields = event => {
 	}
 
 	if (!eventType) {
-		errors.eventType = "Invalid Event Type.";
+		errors.eventType = "Invalid Event Category.";
 	}
 
 	if (privateAccessCode && privateAccessCode.length > 6) {
@@ -510,7 +510,7 @@ class Details extends Component {
 				items={eventTypes}
 				error={errors.eventType}
 				name={"event-types"}
-				label={"Event Type *"}
+				label={"Event Category *"}
 				onChange={e => {
 					const eventType = e.target.value;
 					this.changeDetails({ eventType });


### PR DESCRIPTION
Blocked by big-neon/bn-api-node#387
### References Issues:
https://app.asana.com/0/1136728345391137/1135976069951305
### Description:
Added `Tech` and `Other` category. Changed event type to event category on the event edit page
### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
