### PR TITLE
Fix box office purchase display

### DIFF
--- a/src/components/pages/admin/events/dashboard/orders/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/Index.js
@@ -285,6 +285,9 @@ class OrderList extends Component {
 							columnStyles={columnStyles}
 							ticketTypeList={ticketTypeList}
 							{...order}
+							user={
+								order.on_behalf_of_user ? order.on_behalf_of_user : order.user
+							}
 						/>
 					);
 				})}

--- a/src/components/pages/admin/events/dashboard/orders/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/Index.js
@@ -285,9 +285,6 @@ class OrderList extends Component {
 							columnStyles={columnStyles}
 							ticketTypeList={ticketTypeList}
 							{...order}
-							user={
-								order.on_behalf_of_user ? order.on_behalf_of_user : order.user
-							}
 						/>
 					);
 				})}

--- a/src/components/pages/admin/events/dashboard/orders/OrderRow.js
+++ b/src/components/pages/admin/events/dashboard/orders/OrderRow.js
@@ -102,12 +102,14 @@ const OrderRow = props => {
 		ticketCount,
 		total_in_cents,
 		user,
+		on_behalf_of_user,
 		platform,
 		ticketTypeList,
 		...rest
 	} = props;
-
-	const { first_name, last_name, email, id: userId } = user;
+	const { first_name, last_name, email, id: userId } = on_behalf_of_user
+		? on_behalf_of_user
+		: user;
 
 	const orderPath = `/admin/events/${eventId}/dashboard/orders/manage/${id}`;
 	const userPath = `/admin/fans/${userId}`;

--- a/src/components/pages/admin/events/dashboard/orders/order/Header.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/Header.js
@@ -47,6 +47,7 @@ const Header = ({
 	classes,
 	order_number,
 	user,
+	on_behalf_of_user,
 	displayDate,
 	payment_method,
 	payment_provider,
@@ -55,7 +56,9 @@ const Header = ({
 	fees_in_cents,
 	total_refunded_in_cents
 }) => {
-	const { first_name, last_name, id: userId } = user;
+	const { first_name, last_name, id: userId } = on_behalf_of_user
+		? on_behalf_of_user
+		: user;
 
 	const orderTotalInCents = total_in_cents - fees_in_cents;
 
@@ -79,6 +82,7 @@ const Header = ({
 				Paid {payment_method ? `by ${payment_method}` : ""}{" "}
 				{payment_provider ? `(${payment_provider})` : ""}{" "}
 				{platform ? `via ${platform}` : ""}
+				{on_behalf_of_user ? ` - ${user.first_name} ${user.last_name}` : ""}
 			</Typography>
 
 			<Typography className={classes.orderTotalText}>

--- a/src/components/pages/admin/events/dashboard/orders/order/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/Index.js
@@ -284,7 +284,11 @@ class SingleOrder extends Component {
 						{orderHistory ? (
 							<OrderHistory
 								orderHistory={orderHistory}
-								userId={order.user_id}
+								userId={
+									order.on_behalf_of_user_id
+										? order.on_behalf_of_user_id
+										: order.user_id
+								}
 								eventDetails={eventDetails}
 							/>
 						) : (
@@ -299,7 +303,9 @@ class SingleOrder extends Component {
 							eventId={eventId}
 							organizationId={organizationId}
 							timezone={timezone}
-							user={order.user}
+							user={
+								order.on_behalf_of_user ? order.on_behalf_of_user : order.user
+							}
 							eventId={eventDetails.id}
 							orderId={order.id}
 						/>


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1139476696018194
https://github.com/big-neon/bn-web/issues/1724

### Description:
The API tracks box office orders by treating the box office agent as the user_id for the order and the purchased for user as the on_behalf_of_user_id. The orders API reflects this in that it returns a on_behalf_of_user along with the user when there is a box office purchase.

These changes just reflect the box office user in the frontend by using the on_behalf_of_user instead of the user when it's available.

Down the line we may want to refactor the logic so all orders reflect the end purchasing user in the user_id field but that's likely out of scope for the time being.

### Release Screenshots / Video:
Existing order purchased via box office for different user:
![Screen Shot 2019-09-27 at 3 34 32 PM](https://user-images.githubusercontent.com/1319304/65797733-fb7c6900-e13d-11e9-9e56-07df6f5390bf.png)

Purchasing for a new user via box office:
![Screen Shot 2019-09-27 at 3 35 03 PM](https://user-images.githubusercontent.com/1319304/65797734-fb7c6900-e13d-11e9-8b13-4217880dae46.png)

Both orders appearing in order history using their end user names:
![Screen Shot 2019-09-27 at 3 35 24 PM](https://user-images.githubusercontent.com/1319304/65797735-fb7c6900-e13d-11e9-808c-b31daf6c0908.png)

Order details (note there are no linked orders as this was for a different end user):
![Screen Shot 2019-09-27 at 3 35 39 PM](https://user-images.githubusercontent.com/1319304/65797738-fb7c6900-e13d-11e9-97f8-c032ede2ee3a.png)
![Screen Shot 2019-09-27 at 3 35 43 PM](https://user-images.githubusercontent.com/1319304/65797739-fb7c6900-e13d-11e9-86f5-c3bbe8653846.png)

When I place a second order for my test account (using the its email to link) related orders do show up for that account (but still are empty for the above new@tari.com user):
![Screen Shot 2019-09-27 at 3 52 01 PM](https://user-images.githubusercontent.com/1319304/65798111-d2a8a380-e13e-11e9-9e06-04af1529a983.png)

### Environment Variables:
 * No change

### API requirements:
An earlier API PR added the on_behalf_of_user to the response but that was merged ages ago so no blockers here.