### PR TITLE
Using an enum for ticket type end date when applicable.

### DIFF
--- a/src/components/pages/admin/events/updateSections/TicketType.js
+++ b/src/components/pages/admin/events/updateSections/TicketType.js
@@ -182,13 +182,6 @@ const TicketDetails = observer(props => {
 		onChangeDate
 	} = props;
 
-	let useEndDate = endDate;
-	let useEndTime = endTime;
-	if (!ticketTimesDirty) {
-		useEndDate = eventStartDate.clone();
-		useEndTime = eventStartDate;
-	}
-
 	const pricingErrors = errors && errors.pricing ? errors.pricing : {};
 
 	//If we have errors with fields under 'additional options' or 'schedule a price change', then we need to force fields to be visible
@@ -214,7 +207,10 @@ const TicketDetails = observer(props => {
 
 	const parentTicketTypes = ticketTypes
 		.map((tt, i) => {
-			return { index: i, inner: tt };
+			return {
+				index: i,
+				inner: tt
+			};
 		})
 		// Cannot choose yourself, and cannot choose a ticket type that is parented to yourself
 		.filter(
@@ -236,7 +232,9 @@ const TicketDetails = observer(props => {
 	});
 
 	const onShowAdditionalOptions = () =>
-		updateTicketType(index, { showAdditionalOptions: true });
+		updateTicketType(index, {
+			showAdditionalOptions: true
+		});
 
 	const showCustomStartTimes = saleStartTimeOption === "custom";
 	const showStartSaleWhenTicketSaleEnds = saleStartTimeOption === "parent";
@@ -244,12 +242,21 @@ const TicketDetails = observer(props => {
 	const showCustomEndTime = saleEndTimeOption === "custom";
 
 	const saleStartOptions = [
-		{ value: "immediately", label: "Immediately" },
-		{ value: "custom", label: "At a specific time" }
+		{
+			value: "immediately",
+			label: "Immediately"
+		},
+		{
+			value: "custom",
+			label: "At a specific time"
+		}
 	];
 
 	if (parentTicketTypes.length > 0) {
-		saleStartOptions.push({ value: "parent", label: "When sales end for..." });
+		saleStartOptions.push({
+			value: "parent",
+			label: "When sales end for..."
+		});
 	}
 
 	return (
@@ -268,7 +275,9 @@ const TicketDetails = observer(props => {
 						placeholder="General Admission"
 						type="text"
 						onChange={e => {
-							updateTicketType(index, { name: e.target.value });
+							updateTicketType(index, {
+								name: e.target.value
+							});
 						}}
 						onBlur={validateFields}
 					/>
@@ -284,7 +293,9 @@ const TicketDetails = observer(props => {
 						placeholder="1"
 						type="number"
 						onChange={e => {
-							updateTicketType(index, { capacity: e.target.value });
+							updateTicketType(index, {
+								capacity: e.target.value
+							});
 						}}
 						onBlur={validateFields}
 					/>
@@ -305,7 +316,9 @@ const TicketDetails = observer(props => {
 						placeholder=""
 						type="number"
 						onChange={e => {
-							updateTicketType(index, { priceForDisplay: e.target.value });
+							updateTicketType(index, {
+								priceForDisplay: e.target.value
+							});
 						}}
 						onBlur={validateFields}
 					/>
@@ -316,7 +329,9 @@ const TicketDetails = observer(props => {
 				<div>
 					<Hidden mdUp>
 						<Button
-							style={{ width: "100%" }}
+							style={{
+								width: "100%"
+							}}
 							variant="additional"
 							onClick={onShowAdditionalOptions}
 						>
@@ -374,7 +389,10 @@ const TicketDetails = observer(props => {
 								type="date"
 								onChange={startDate => {
 									onChangeDate();
-									updateTicketType(index, { parentId: null, startDate });
+									updateTicketType(index, {
+										parentId: null,
+										startDate
+									});
 								}}
 								onBlur={validateFields}
 								minDate={false}
@@ -398,7 +416,10 @@ const TicketDetails = observer(props => {
 								type="time"
 								onChange={startTime => {
 									onChangeDate();
-									updateTicketType(index, { parentId: null, startTime });
+									updateTicketType(index, {
+										parentId: null,
+										startTime
+									});
 								}}
 								onBlur={validateFields}
 								minDate={false}
@@ -448,10 +469,22 @@ const TicketDetails = observer(props => {
 							disabled={isCancelled}
 							value={saleEndTimeOption || "close"}
 							items={[
-								{ value: "door", label: "Door Time" },
-								{ value: "start", label: "Event Start" },
-								{ value: "close", label: "Event End" },
-								{ value: "custom", label: "At a specific time" }
+								{
+									value: "door",
+									label: "Door Time"
+								},
+								{
+									value: "start",
+									label: "Event Start"
+								},
+								{
+									value: "close",
+									label: "Event End"
+								},
+								{
+									value: "custom",
+									label: "At a specific time"
+								}
 							]}
 							name={"close-times"}
 							label={"Sales end *"}
@@ -473,13 +506,15 @@ const TicketDetails = observer(props => {
 							<DateTimePickerGroup
 								disabled={isCancelled}
 								error={errors.endDate}
-								value={useEndDate}
+								value={endDate}
 								name="endDate"
 								type="date"
 								label="End date *"
 								onChange={endDate => {
 									onChangeDate();
-									updateTicketType(index, { endDate });
+									updateTicketType(index, {
+										endDate
+									});
 								}}
 								onBlur={validateFields}
 								minDate={false}
@@ -497,13 +532,15 @@ const TicketDetails = observer(props => {
 							<DateTimePickerGroup
 								disabled={isCancelled}
 								error={errors.endTime}
-								value={useEndTime}
+								value={endTime}
 								name="endTime"
 								type="time"
 								label="End time *"
 								onChange={endTime => {
 									onChangeDate();
-									updateTicketType(index, { endTime });
+									updateTicketType(index, {
+										endTime
+									});
 								}}
 								onBlur={validateFields}
 								minDate={false}
@@ -543,7 +580,9 @@ const TicketDetails = observer(props => {
 							placeholder="Short description of this ticket type"
 							type="text"
 							onChange={e => {
-								updateTicketType(index, { description: e.target.value });
+								updateTicketType(index, {
+									description: e.target.value
+								});
 							}}
 							onBlur={validateFields}
 						/>
@@ -561,7 +600,9 @@ const TicketDetails = observer(props => {
 							<Button
 								variant="additional"
 								onClick={() => {
-									updateTicketType(index, { showMaxTicketsPerCustomer: true });
+									updateTicketType(index, {
+										showMaxTicketsPerCustomer: true
+									});
 								}}
 							>
 								Set max tix per customer
@@ -599,7 +640,9 @@ const TicketDetails = observer(props => {
 							<Button
 								variant="additional"
 								onClick={() => {
-									updateTicketType(index, { showVisibility: true });
+									updateTicketType(index, {
+										showVisibility: true
+									});
 								}}
 							>
 								Set visibility/access rules
@@ -614,7 +657,9 @@ const TicketDetails = observer(props => {
 								name={"visibility"}
 								label={"Visibility *"}
 								onChange={e => {
-									updateTicketType(index, { visibility: e.target.value });
+									updateTicketType(index, {
+										visibility: e.target.value
+									});
 								}}
 							/>
 						</Collapse>
@@ -632,7 +677,9 @@ const TicketDetails = observer(props => {
 							<Button
 								variant="additional"
 								onClick={() => {
-									updateTicketType(index, { showCartQuantityIncrement: true });
+									updateTicketType(index, {
+										showCartQuantityIncrement: true
+									});
 								}}
 							>
 								Enforce qty increment
@@ -649,7 +696,9 @@ const TicketDetails = observer(props => {
 								placeholder=""
 								type="number"
 								onChange={e => {
-									updateTicketType(index, { increment: e.target.value });
+									updateTicketType(index, {
+										increment: e.target.value
+									});
 								}}
 								onBlur={validateFields}
 							/>
@@ -668,7 +717,9 @@ const TicketDetails = observer(props => {
 							<Button
 								variant="additional"
 								onClick={() => {
-									updateTicketType(index, { showAdditionalFee: true });
+									updateTicketType(index, {
+										showAdditionalFee: true
+									});
 								}}
 							>
 								Increase service fee/rev share
@@ -720,7 +771,9 @@ const TicketDetails = observer(props => {
 							variant="additional"
 							onClick={() => {
 								eventUpdateStore.addTicketPricing(index);
-								updateTicketType(index, { showPricing: true });
+								updateTicketType(index, {
+									showPricing: true
+								});
 							}}
 						>
 							Schedule a price change
@@ -754,7 +807,9 @@ const TicketDetails = observer(props => {
 											const updatedPricing = pricing;
 											updatedPricing[pricePointIndex] = updatedPricePoint;
 
-											updateTicketType(index, { pricing: updatedPricing });
+											updateTicketType(index, {
+												pricing: updatedPricing
+											});
 										}}
 										errors={pricingErrors[pricePointIndex] || {}}
 										validateFields={validateFields}

--- a/src/components/pages/admin/events/updateSections/Tickets.js
+++ b/src/components/pages/admin/events/updateSections/Tickets.js
@@ -59,15 +59,17 @@ const formatForSaving = (ticketTypes, event) => {
 			}
 		}
 
+		let end_date_type = null;
 		switch (saleEndTimeOption) {
 			case "door":
-				endDate = moment(doorTime);
+				end_date_type = "DoorTime";
 				break;
 			case "start":
-				endDate = moment(eventDate);
+				end_date_type = "EventStart";
 				break;
 			//If no option or set to custom, assume they're updating it manually
 			case "custom":
+				end_date_type = "Manual";
 				endDate = moment(endDate);
 				if (endTime) {
 					endDate = endDate.set({
@@ -79,12 +81,7 @@ const formatForSaving = (ticketTypes, event) => {
 				break;
 			case "close":
 			default:
-				endDate = event.endTime
-					? moment(event.endTime)
-					: moment(eventDate).add(
-						DEFAULT_END_TIME_HOURS_AFTER_SHOW_TIME,
-						"hours"
-					  );
+				end_date_type = "EventEnd";
 				break;
 		}
 
@@ -153,7 +150,11 @@ const formatForSaving = (ticketTypes, event) => {
 			capacity: Number(capacity),
 			increment: Number(increment),
 			start_date,
-			end_date: endDate.utc().format(moment.HTML5_FMT.DATETIME_LOCAL_MS),
+			end_date_type, // `DoorTime`, `EventEnd`, `EventStart`,
+			end_date:
+				endDate && endDate.isValid()
+					? endDate.utc().format(moment.HTML5_FMT.DATETIME_LOCAL_MS)
+					: null,
 			limit_per_person:
 				!limitPerPerson || isNaN(limitPerPerson) ? 0 : Number(limitPerPerson),
 			price_in_cents: Number(priceForDisplay) * 100,
@@ -183,6 +184,7 @@ const formatForInput = (ticket_types, event) => {
 			limit_per_person,
 			ticket_pricing,
 			start_date,
+			end_date_type,
 			end_date,
 			price_in_cents,
 			status,
@@ -222,8 +224,8 @@ const formatForInput = (ticket_types, event) => {
 			// }
 		});
 
-		const ticketStartDate = start_date ? moment.utc(start_date).local() : null;
-		const ticketEndDate = end_date ? moment.utc(end_date).local() : null;
+		const ticketStartDate = start_date ? moment.utc(start_date) : null;
+		const ticketEndDate = end_date ? moment.utc(end_date) : moment.utc();
 
 		let saleEndTimeOption;
 		const { doorTime, eventDate, endTime } = event;
@@ -231,11 +233,11 @@ const formatForInput = (ticket_types, event) => {
 			? moment(endTime)
 			: moment(eventDate).add(DEFAULT_END_TIME_HOURS_AFTER_SHOW_TIME, "hours");
 
-		if (ticketEndDate.isSame(doorTime)) {
+		if (end_date_type === "DoorTime") {
 			saleEndTimeOption = "door";
-		} else if (ticketEndDate.isSame(eventDate)) {
+		} else if (end_date_type === "EventStart") {
 			saleEndTimeOption = "start";
-		} else if (ticketEndDate.isSame(closeTime)) {
+		} else if (end_date_type === "EventEnd") {
 			saleEndTimeOption = "close";
 		} else {
 			//If it's not the same as any of the above the user must have edited it
@@ -271,7 +273,7 @@ const formatForInput = (ticket_types, event) => {
 			startDate: ticketStartDate ? ticketStartDate.clone() : null,
 			startTime: ticketStartDate,
 			saleEndTimeOption,
-			endDate: ticketEndDate.clone(),
+			endDate: ticketEndDate ? ticketEndDate.clone() : null,
 			endTime: ticketEndDate,
 			priceAtDoor, //TODO get the actual value when API works
 			pricing,

--- a/src/stores/eventUpdate.js
+++ b/src/stores/eventUpdate.js
@@ -176,7 +176,7 @@ class EventUpdate {
 			//By default the server will create a Default ticket price point, anything additional added to this array is an override.
 			pricing: [],
 			...updateTimezonesInObjects(
-				{ startDate, startTime: startDate, endDate },
+				{ startDate, startTime: startDate, endDate, endTime: endDate.clone() },
 				this.timezone,
 				false
 			)


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1141131926912004

### Description:
When applicable, use an enum for the event end time. Can override the date by using `Manual` and passing along a set date.

Looks the same but wont try to guess `DoorTime`, `StartTime` or `CloseTime` based on the set time.

### Release Screenshots / Video:
No visual changes.

### Environment Variables:
 * No change

### API requirements:
https://github.com/big-neon/bn-api/pull/1508
https://github.com/big-neon/bn-api-node/pull/391