### PR TITLE
Set the organization_id when viewing an order or an event

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,6 @@
 
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx\{0,1\}$")
 AUTO_FIX_FILES=$(git config custom.autofix)
-AUTO_FIX_FILES=true
 if [[ "$STAGED_FILES" = "" ]]; then
   echo -e "\nNo staged files to validate.\n"
   exit 0

--- a/src/components/pages/admin/events/dashboard/orders/order/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/Index.js
@@ -78,8 +78,9 @@ class SingleOrder extends Component {
 		}
 	}
 
-	loadAll() {
-		this.loadEventDetails();
+	async loadAll() {
+		await this.loadEventDetails();
+
 		this.loadOrder();
 		this.loadOrderItems();
 		this.loadOrderHistory();
@@ -87,29 +88,35 @@ class SingleOrder extends Component {
 
 	loadEventDetails() {
 		const { eventId } = this.state;
-		Bigneon()
-			.events.read({ id: eventId })
-			.then(response => {
-				const { data } = response;
+		return new Promise((resolve, reject) => {
+			Bigneon()
+				.events.read({ id: eventId })
+				.then(response => {
+					const { data } = response;
 
-				const { event_start, venue } = data;
+					const { event_start, venue } = data;
 
-				const displayDate = moment(event_start)
-					.tz(venue.timezone)
-					.format("ddd, MMM DD, YYYY");
+					const displayDate = moment(event_start)
+						.tz(venue.timezone)
+						.format("ddd, MMM DD, YYYY");
 
-				this.setState({
-					eventDetails: { ...data, displayDate }
+					this.setState({
+						eventDetails: { ...data, displayDate }
+					});
+					user.setCurrentOrganizationRolesAndScopes(data.organization_id);
+					resolve();
+				})
+				.catch(error => {
+					console.error(error);
+
+					notifications.showFromErrorResponse({
+						defaultMessage: "Loading event details failed.",
+						error
+					});
+					reject();
 				});
-			})
-			.catch(error => {
-				console.error(error);
+		});
 
-				notifications.showFromErrorResponse({
-					defaultMessage: "Loading event details failed.",
-					error
-				});
-			});
 	}
 
 	loadOrder() {

--- a/src/components/pages/events/ViewEvent.js
+++ b/src/components/pages/events/ViewEvent.js
@@ -17,7 +17,8 @@ import {
 	secondaryHex,
 	textColorPrimary
 } from "../../../config/theme";
-import EventDetailsOverlayCard from "../../elements/event/EventDetailsOverlayCard";
+import EventDetailsOverlayCard
+	from "../../elements/event/EventDetailsOverlayCard";
 import nl2br from "../../../helpers/nl2br";
 import Meta from "./Meta";
 import Loader from "../../elements/loaders/Loader";
@@ -35,7 +36,8 @@ import EventDescriptionBody from "./EventDescriptionBody";
 import addressLineSplit from "../../../helpers/addressLineSplit";
 import layout from "../../../stores/layout";
 import Settings from "../../../config/settings";
-import EventCallToActionAppBar from "../../elements/header/EventCallToActionAppBar";
+import EventCallToActionAppBar
+	from "../../elements/header/EventCallToActionAppBar";
 import user from "../../../stores/user";
 import { insertScript } from "../../../helpers/insertScript";
 import replaceIdWithSlug from "../../../helpers/replaceIdWithSlug";
@@ -172,7 +174,7 @@ class ViewEvent extends Component {
 					});
 				},
 				() => {
-					const { id: selectedEventId, slug } = selectedEvent.event;
+					const { id: selectedEventId, slug, organization_id: organizationId } = selectedEvent.event;
 
 					//Replace the id in the URL with the slug if we have it and it isn't currently set
 					if (id === selectedEventId && slug) {
@@ -180,6 +182,13 @@ class ViewEvent extends Component {
 					}
 
 					analytics.viewContent([selectedEventId], getAllUrlParams());
+					if (user.isAuthenticated) {
+						const { organizations } = user;
+						if (organizations.hasOwnProperty(organizationId)) {
+							user.setCurrentOrganizationRolesAndScopes(organizationId, false);
+						}
+					}
+
 				}
 			);
 		} else {
@@ -407,7 +416,10 @@ class ViewEvent extends Component {
 
 				<div className={classes.spacer}/>
 
-				<EventDetail classes={classes} iconUrl={"/icons/events-black.svg"}>
+				<EventDetail
+					classes={classes}
+					iconUrl={"/icons/events-black.svg"}
+				>
 					<Typography className={classes.eventDetailText}>
 						<span className={classes.eventDetailBoldText}>
 							{displayEventStartDate}
@@ -423,7 +435,10 @@ class ViewEvent extends Component {
 					<div>
 						<Divider className={classes.divider}/>
 
-						<EventDetail classes={classes} iconUrl={"/icons/ticket-black.svg"}>
+						<EventDetail
+							classes={classes}
+							iconUrl={"/icons/ticket-black.svg"}
+						>
 							<Typography className={classes.eventDetailText}>
 								Tickets from {priceTagText}
 							</Typography>
@@ -433,7 +448,10 @@ class ViewEvent extends Component {
 
 				<Divider className={classes.divider}/>
 
-				<EventDetail classes={classes} iconUrl={"/icons/location-black.svg"}>
+				<EventDetail
+					classes={classes}
+					iconUrl={"/icons/location-black.svg"}
+				>
 					<Typography className={classes.eventDetailText}>
 						{venue.name}
 						<br/>
@@ -524,7 +542,9 @@ class ViewEvent extends Component {
 
 				{/*MOBILE*/}
 				<Hidden mdUp>
-					<MaintainAspectRatio aspectRatio={Settings().promoImageAspectRatio}>
+					<MaintainAspectRatio
+						aspectRatio={Settings().promoImageAspectRatio}
+					>
 						<div
 							className={classes.mobileHeaderImage}
 							style={mobilePromoImageStyle}
@@ -546,7 +566,10 @@ class ViewEvent extends Component {
 
 						{artists && artists.length !== 0 ? (
 							<Typography className={classes.cardArtists}>
-								<SupportingArtistsLabel eventName={name} artists={artists}/>
+								<SupportingArtistsLabel
+									eventName={name}
+									artists={artists}
+								/>
 							</Typography>
 						) : null}
 
@@ -560,27 +583,37 @@ class ViewEvent extends Component {
 									classes={classes}
 									iconUrl={"/icons/event-detail-black.svg"}
 								>
-									<Typography className={classes.eventDetailText}>
-										{showAllAdditionalInfo ||
-										additional_info.length <= ADDITIONAL_INFO_CHAR_LIMIT ? (
-												<LinkifyReact options={options}>
-													{additional_info}
-												</LinkifyReact>
-											) : (
-												nl2br(
-													ellipsis(additional_info, ADDITIONAL_INFO_CHAR_LIMIT)
+									<Typography
+										className={classes.eventDetailText}
+									>
+										{
+											showAllAdditionalInfo ||
+											additional_info.length <= ADDITIONAL_INFO_CHAR_LIMIT ?
+												(
+													<LinkifyReact
+														options={options}
+													>
+														{additional_info}
+													</LinkifyReact>
+												) : (
+													nl2br(
+														ellipsis(additional_info, ADDITIONAL_INFO_CHAR_LIMIT)
+													)
 												)
-											)}
+										}
 
-										{additional_info &&
-										additional_info.length > ADDITIONAL_INFO_CHAR_LIMIT ? (
-												<span
-													className={classes.eventDetailLinkText}
-													onClick={this.showHideMoreAdditionalInfo.bind(this)}
-												>
-													{showAllAdditionalInfo ? "Read less" : "Read more"}
-												</span>
-											) : null}
+										{
+											additional_info &&
+											additional_info.length > ADDITIONAL_INFO_CHAR_LIMIT ?
+												(
+													<span
+														className={classes.eventDetailLinkText}
+														onClick={this.showHideMoreAdditionalInfo.bind(this)}
+													>
+														{showAllAdditionalInfo ? "Read less" : "Read more"}
+													</span>
+												) : null
+										}
 									</Typography>
 								</EventDetail>
 


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1139351286534657
### Description:
When viewing an order from a direct link it first sets the current org id for the user.
When viewing an event it changes the current org if you are a part of that org.
### Release Screenshots / Video:
http://cl.ly/4413d93f9375
### Environment Variables:
 * No change

### API requirements:
