### PR TITLE
Fix fee calculation for orders to include event fee

### DIFF
--- a/src/components/pages/admin/events/dashboard/orders/order/Index.js
+++ b/src/components/pages/admin/events/dashboard/orders/order/Index.js
@@ -139,7 +139,7 @@ class SingleOrder extends Component {
 				items.forEach(({ item_type, unit_price_in_cents, quantity }) => {
 					//Only include fee type items
 					if (
-						["CreditCardFees", "PerUnitFees", "CreditCardFees"].indexOf(
+						["CreditCardFees", "PerUnitFees", "EventFees"].indexOf(
 							item_type
 						) > -1
 					) {


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1145552426833993

### Description:
It was noticed that the price and fees total on the order management page was calculated incorrectly. 

Dug into it and noticed we are taking the total of the order and subtracting fees here:
https://github.com/big-neon/bn-web/blob/bf23da36723cf8a99270a1ea55497e8b83bd2450/src/components/pages/admin/events/dashboard/orders/order/Header.js#L63

But not including the event fee (we include credit card fees twice so guessing it was a typo at the time):
https://github.com/big-neon/bn-web/blob/bd23b77a69a57020b9006e65a1a11dc849753f2c/src/components/pages/admin/events/dashboard/orders/order/Index.js#L142

This just modifies the logic to include the event fee in the fee total which fixes the ticket total as well given that calculation.

### Release Screenshots / Video:

Example is of an order with: 3 tickets at $30 each with fees of $0.10 each and a $1.00 event fee.

Before:
![Screen Shot 2019-10-18 at 1 28 47 PM](https://user-images.githubusercontent.com/1319304/67117255-3a876280-f1b0-11e9-9e2e-0b303c3131b8.png)

Fixed:
![Screen Shot 2019-10-18 at 1 58 00 PM](https://user-images.githubusercontent.com/1319304/67117241-2ba0b000-f1b0-11e9-8a14-ec0a918c0eb1.png)

### Environment Variables:
 * No change

### API requirements:
