### PR TITLE
automated tests in docker

### DIFF
--- a/selenium/qa/Dockerfile
+++ b/selenium/qa/Dockerfile
@@ -3,13 +3,7 @@ FROM  maven:3.3-jdk-8 AS builder
 WORKDIR /usr/src/test
 
 COPY pom.xml .
-
-RUN mvn verify clean --fail-never
-
-COPY config ./config/
 COPY src ./src/
-
-RUN mvn verify --fail-never
-
-
-CMD mvn verify -Dbrowser=hub -Dhuburl=http://$HUB_HOST:$HUB_PORT/wd/hub -Dconfig=suite.conf.json -Dbaseurl=$BASE_URL -Denvironment=chrome
+COPY config ./config/
+RUN echo 'Wait'
+CMD mvn clean verify -P hub -Dhuburl=http://"$HUB_HOST":"$HUB_PORT"/wd/hub -Dconfig=suite.conf.json -Dbaseurl=$BASE_URL

--- a/selenium/qa/config/hub/testng.xml
+++ b/selenium/qa/config/hub/testng.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="allSuites">
+	<suite-files>
+		<suite-file path="../parallel_suite.xml"/>
+		<suite-file path="../sequential_suite.xml"/>
+	</suite-files>
+</suite>

--- a/selenium/qa/config/parallel_suite.xml
+++ b/selenium/qa/config/parallel_suite.xml
@@ -1,22 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Pool" parallel="tests">
-  <test thread-count="2" name="Chrome" parallel="classes">
+<suite name="Parallel" parallel="tests" thread-count="2">
+  <test name="Chrome" parallel="classes">
     <parameter name="config" value="suite.conf.json"/>
     <parameter name="environment" value="chrome"/>
     <classes>
       <class name="test.LoginWithFacebookStepsIT"/>
       <class name="test.LoginStepsIT"/>
       <class name="test.SignUpStepsIT"/>
+      <class name="test.CreateOrganizationStepsIT"/>
+      <class name="test.PublishEventWithDeleteEventIT"/>
+      <class name="test.CancelEventStepsIT"/>
+      <class name="test.CreateDraftEventStepsIT"/>
+      <class name="test.CreateEventWithAdditionalOptionsStepsIT"/>
     </classes>
   </test>
-  <test thread-count="2" name="Firefox" parallel="classes">
+  <test name="Firefox" parallel="classes">
 	<parameter name="config" value="suite.conf.json"/>
     <parameter name="environment" value="firefox"/>
     <classes>
       <class name="test.LoginWithFacebookStepsIT"/>
       <class name="test.LoginStepsIT"/>
       <class name="test.SignUpStepsIT"/>
+      <class name="test.CreateOrganizationStepsIT"/>
+      <class name="test.PublishEventWithDeleteEventIT"/>
+      <class name="test.CancelEventStepsIT"/>
+      <class name="test.CreateDraftEventStepsIT"/>
+      <class name="test.CreateEventWithAdditionalOptionsStepsIT"/>
     </classes>
   </test> 
 </suite>

--- a/selenium/qa/config/sequential_suite.xml
+++ b/selenium/qa/config/sequential_suite.xml
@@ -6,17 +6,11 @@
     <parameter name="environment" value="chrome"/>
     <classes>
       <class name="test.ForgotPasswordStepsIT"/>
-      <class name="test.CreateOrganizationStepsIT"/>
       <class name="test.CreateEventStepsIT"/>
       <class name="test.PurchaseStepsIT"/>
       <class name="test.PurchaseWithTicketChangeStepsIT"/>
-      <!-- <class name="test.TransferTicketStepsIT"/> -->
-      <class name="test.CancelEventStepsIT"/>
-      <class name="test.CreateEventWithAdditionalOptionsStepsIT"/>
-      <class name="test.CreateDraftEventStepsIT"/>
       <class name="test.EditEventInformationStepsIT"/>
       <class name="test.OrderManagmentSearchForOrdersStepsIT"/>
-      <class name="test.PublishEventWithDeleteEventIT"/>
        <class name="test.BoxOfficeSellTicketStepsIT"/>
       <class name="test.VenueStepsIT"/>
     </classes>
@@ -26,17 +20,11 @@
     <parameter name="environment" value="firefox"/>
     <classes>
       <class name="test.ForgotPasswordStepsIT"/>
-      <class name="test.CreateOrganizationStepsIT"/>
-      <class name="test.CreateEventStepsIT"/>
+      <class name="test.CreateEventStepsIT"/> 
       <class name="test.PurchaseStepsIT"/> 
       <class name="test.PurchaseWithTicketChangeStepsIT"/>
-     <!--  <class name="test.TransferTicketStepsIT"/> -->
-      <class name="test.CancelEventStepsIT"/>
-      <class name="test.CreateEventWithAdditionalOptionsStepsIT"/>
-      <class name="test.CreateDraftEventStepsIT"/>
       <class name="test.EditEventInformationStepsIT"/>
       <class name="test.OrderManagmentSearchForOrdersStepsIT"/>
-      <class name="test.PublishEventWithDeleteEventIT"/>
       <class name="test.BoxOfficeSellTicketStepsIT"/>
       <class name="test.VenueStepsIT"/>
     </classes>

--- a/selenium/qa/docker-compose.yml
+++ b/selenium/qa/docker-compose.yml
@@ -1,4 +1,6 @@
-# To execute this docker-compose yml file use `docker-compose -f <file_name> up`
+# To execute this docker-compose yml file use `docker-compose -f <file_name> up --build test`
+#--build test option is so that each time docker compose is run test service is rebuild, so that new changes to code 
+# are copied to container, however if container already exists, mavan repository is not downloaded again (so that is chached)
 # Add the `-d` flag at the end for detached execution
 version: "3"
 services:
@@ -39,29 +41,38 @@ services:
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
-
-  test-chrome:
+  test:
     build: ./
     depends_on:
       - chrome
-    environment:
-      - HUB_HOST=selenium-hub
-      - HUB_PORT=4444
-
-  test-firefox:
-    build: ./
-    depends_on:
-     - firefox
-    environment:
-     - HUB_HOST=selenium-hub
-     - HUB_PORT=4444
-     - BASE_URL=https://develop.bigneon.com
-
-  test-chrome-debug:
-    build: ./
-    depends_on:
-      - chrome-debug
+      - firefox
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
       - BASE_URL=https://develop.bigneon.com
+      
+#  test-chrome:
+#    build: ./
+#    depends_on:
+#      - chrome
+#    environment:
+#      - HUB_HOST=selenium-hub
+#      - HUB_PORT=4444
+
+#  test-firefox:
+#    build: ./
+#    depends_on:
+#     - firefox
+#    environment:
+#     - HUB_HOST=selenium-hub
+#     - HUB_PORT=4444
+#     - BASE_URL=https://develop.bigneon.com
+
+#  test-chrome-debug:
+#    build: ./
+#    depends_on:
+#      - chrome-debug
+#    environment:
+#      - HUB_HOST=selenium-hub
+#      - HUB_PORT=4444
+#      - BASE_URL=https://develop.bigneon.com

--- a/selenium/qa/pom.xml
+++ b/selenium/qa/pom.xml
@@ -21,6 +21,10 @@
 		<apache.commons.lang>3.8</apache.commons.lang>
 		<maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
 		<maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
+		<huburl/>
+		<webdriver.chrome.driver/>
+		<webdriver.gecko.driver/>
+		<webdriver.edge.driver/>
 		<browser>rm</browser>
 		<baseurl>https://develop.bigneon.com/</baseurl>
 
@@ -89,9 +93,9 @@
 					<systemPropertyVariables>
 						<browser>${browser}</browser>
 						<baseurl>${baseurl}</baseurl>
-                        <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
-                        <webdriver.gecko.driver>${webdriver.gecko.driver}</webdriver.gecko.driver>
-                        <webdriver.edge.driver>${webdriver.edge.driver}</webdriver.edge.driver>
+						<webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
+						<webdriver.gecko.driver>${webdriver.gecko.driver}</webdriver.gecko.driver>
+						<webdriver.edge.driver>${webdriver.edge.driver}</webdriver.edge.driver>
 						<huburl>${huburl}</huburl>
 					</systemPropertyVariables>
 					<suiteXmlFiles>
@@ -127,6 +131,78 @@
 							</systemPropertyVariables>
 						</configuration>
 					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>hub</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<suiteXmlFiles>
+								<suiteXmlFile>config/hub/testng.xml</suiteXmlFile>
+							</suiteXmlFiles>
+							<systemPropertyVariables>
+								<browser>hub</browser>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+					<!-- <plugin>
+						<groupId>ch.fortysix</groupId>
+						<artifactId>maven-postman-plugin</artifactId>
+						<version>0.1.6</version>
+						<executions>
+							<execution>
+								<id>Report Generation</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>send-mail</goal>
+								</goals>
+								<inherited>true</inherited>
+								<configuration>
+									From Email address
+									<from>mroywyn@gmail.com</from>
+									Email subject
+									<subject>bn-web selenium test report</subject>
+									Fail the build if the mail doesn't reach
+									<failonerror>false</failonerror>
+									Email Body Content
+									<htmlMessage>
+                                    <![CDATA[
+                                    <p>New test build triggered!</p>
+                                    <p>Attached html file contains the test result status</p> 
+                                    ]]>
+									</htmlMessage>
+									host
+									 <mailhost>smtp.gmail.com</mailhost> 
+									 port of the host 
+									 <mailport>465</mailport> 
+									 <mailssl>true</mailssl> 
+									 <mailAltConfig>true</mailAltConfig> 
+										Email Authentication(Username and Password)
+									 <mailuser>mroywyn@gmail.com</mailuser> 
+									<mailpassword>gnomename8</mailpassword>
+									<receivers>
+										To Email address
+										<receiver>kolesar.mihal@gmail.com</receiver>
+									</receivers>
+									<fileSets>
+										<fileSet>
+											Report directory Path
+											<directory>${basedir}/target/failsafe-reports/</directory>
+											<includes>
+												Report file name
+												<include>emailable-report.html</include>
+											</includes>
+										</fileSet>
+									</fileSets>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin> -->
 				</plugins>
 			</build>
 		</profile>

--- a/selenium/qa/src/test/java/config/DriverFactory.java
+++ b/selenium/qa/src/test/java/config/DriverFactory.java
@@ -32,7 +32,8 @@ public class DriverFactory {
                 case HUB:
                     System.out.println("Remote hub");
                     String huburl = System.getProperty("huburl");
-                    manager = new RemoteDriverManager(huburl, config, environment);
+                    String configFileName = System.getProperty("config");
+                    manager = new HubRemoteDriverManager(huburl, configFileName, environment);
                     break;
                 default:
                     System.out.println("Local default");

--- a/selenium/qa/src/test/java/config/HubRemoteDriverManager.java
+++ b/selenium/qa/src/test/java/config/HubRemoteDriverManager.java
@@ -1,0 +1,50 @@
+package config;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+public class HubRemoteDriverManager extends DriverManager {
+	
+	private String url;
+	private String config_file;
+	private String environment;
+
+	public HubRemoteDriverManager(String url, String config_file, String environment) {
+		super();
+		this.url = url;
+		this.config_file = config_file;
+		this.environment = environment;
+	}
+
+	@Override
+	protected void startService() {
+	}
+
+	@Override
+	protected void stopService() {		
+	}
+	
+	public RemoteWebDriver createRemoteWebDriver(String config_file, String environment) throws Exception {
+		DesiredCapabilities capabilities = new DesiredCapabilities();
+		capabilities.setBrowserName(environment);
+		return new RemoteWebDriver(new URL(this.url), capabilities);
+	}
+
+	@Override
+	protected void createDriver() throws MalformedURLException, Exception {
+		driver = createRemoteWebDriver(this.config_file, this.environment);
+	}
+
+	@Override
+	public WebDriver getDriver() throws Exception {
+		if (driver == null) {
+			startService();
+			createDriver();
+		}
+		return driver;
+	}
+}

--- a/selenium/qa/src/test/java/pages/FacebookLoginPage.java
+++ b/selenium/qa/src/test/java/pages/FacebookLoginPage.java
@@ -33,16 +33,12 @@ public class FacebookLoginPage extends BasePage {
 		explicitWait(10, 250, ExpectedConditions.visibilityOf(emailOrPhoneField));
 		emailOrPhoneField.sendKeys(phoneOrMail);
 		passwordField.sendKeys(password);
-		loginButton.click();
+		waitVisibilityAndBrowserCheckClick(loginButton);
 		try {
 			WebElement firstTimeLoginConfirmButton = explicitWait(10, ExpectedConditions
 					.visibilityOfElementLocated(By.xpath("//form//tbody//button[@name='__CONFIRM__']")));
-			firstTimeLoginConfirmButton.click();
+			waitVisibilityAndBrowserCheckClick(firstTimeLoginConfirmButton);
 		} catch (Exception e) {
-			if (!(e instanceof TimeoutException)) {
-				System.out.println(e.getMessage());
-			}
-
 		}
 		boolean retVal = explicitWait(5, ExpectedConditions.numberOfWindowsToBe(1));
 		return retVal;

--- a/selenium/qa/src/test/java/pages/LoginPage.java
+++ b/selenium/qa/src/test/java/pages/LoginPage.java
@@ -85,10 +85,10 @@ public class LoginPage extends BasePage {
 		passwordField.sendKeys(password);
 		clickOnRecaptcha();
 		explicitWait(10, ExpectedConditions.elementToBeClickable(loginSubmitButton));
-		loginSubmitButton.click();
+		waitVisibilityAndBrowserCheckClick(loginSubmitButton);
 		if (checkForLoginFailedMessage()) {
 			waitForTime(1000);
-			loginSubmitButton.click();
+			waitVisibilityAndBrowserCheckClick(loginSubmitButton);
 		}
 	}
 	
@@ -146,7 +146,7 @@ public class LoginPage extends BasePage {
 
 	private boolean loginWithFacebook(String phoneOrMail, String password) {
 		String parentWindowHandle = driver.getWindowHandle();
-		loginFacebook.click();
+		waitVisibilityAndBrowserCheckClick(loginFacebook);
 		explicitWait(10, ExpectedConditions.numberOfWindowsToBe(2));
 		Set<String> allWindows = driver.getWindowHandles();
 		String currentWindowHandle = driver.getWindowHandle();
@@ -174,13 +174,13 @@ public class LoginPage extends BasePage {
 
 	public void clickOnRegisterLink() {
 		explicitWait(10, ExpectedConditions.elementToBeClickable(registerLink));
-		registerLink.click();
+		waitVisibilityAndBrowserCheckClick(registerLink);
 	}
 
 	public boolean enterMailAndClickOnResetPassword(String email) {
 		explicitWait(10, 500, ExpectedConditions.presenceOfElementLocated(By.xpath("//div[@role='dialog']//form")));
 		waitVisibilityAndSendKeys(forgotPasswordEmailField, email);
-		explicitWaitForVisibilityAndClickableWithClick(forgotPasswordConfirmButton);
+		waitVisibilityAndBrowserCheckClick(forgotPasswordConfirmButton);
 		isNotificationDisplayedWithMessage(MsgConstants.resetPasswordMessage(email));
 		return true;
 	}

--- a/selenium/qa/src/test/java/pages/admin/organizations/CreateOrganizationPage.java
+++ b/selenium/qa/src/test/java/pages/admin/organizations/CreateOrganizationPage.java
@@ -57,7 +57,7 @@ public class CreateOrganizationPage extends BasePage {
 		waitForTime(2000);
 		addressAutoSearchField.sendKeys(address);
 		WebElement firstInList = explicitWait(15, ExpectedConditions.visibilityOfElementLocated(By.xpath(
-				"///div[contains(@class,'autocomplete-dropdown-container')]/div[contains(@class,'suggestion-item')]")));
+				"//div[contains(@class,'autocomplete-dropdown-container')]/div[contains(@class,'suggestion-item')]")));
 		explicitWaitForVisibilityAndClickableWithClick(firstInList);
 	}
 

--- a/selenium/qa/src/test/java/pages/components/admin/AddTicketTypeComponent.java
+++ b/selenium/qa/src/test/java/pages/components/admin/AddTicketTypeComponent.java
@@ -64,7 +64,7 @@ public class AddTicketTypeComponent extends BaseComponent {
 	@FindBy(id = "endDate")
 	private WebElement endDate;
 
-	@FindBy(id = "endTime")
+	@FindBy(xpath = "//div[div[div[span[span[contains(text(),'Sales end')]]]]]//input[@id='endTime']")
 	private WebElement endTime;
 
 	public AddTicketTypeComponent(WebDriver driver) {
@@ -147,7 +147,7 @@ public class AddTicketTypeComponent extends BaseComponent {
 
 	private void enterTime(WebElement element, String time) {
 		TimeMenuDropDown timeDropDown = new TimeMenuDropDown(driver);
-		timeDropDown.selectTime(startTime, time);
+		timeDropDown.selectTime(element, time);
 	}
 
 	private void clickOnAdditionalOptionsButton() {

--- a/selenium/qa/src/test/java/test/CreateEventWithAdditionalOptionsStepsIT.java
+++ b/selenium/qa/src/test/java/test/CreateEventWithAdditionalOptionsStepsIT.java
@@ -4,6 +4,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import model.AdditionalOptionsTicketType.SaleEnd;
 import model.AdditionalOptionsTicketType.SaleStart;
 import model.Event;
 import model.TicketType;
@@ -44,13 +45,15 @@ public class CreateEventWithAdditionalOptionsStepsIT extends BaseSteps {
 	public static Object[][] data() throws Exception {
 		User superuser = User.generateUserFromJson(DataConstants.SUPERUSER_DATA_KEY);
 		Event event = (Event) Event.generateEventFromJson("event_data_with_additional_steps_std", true, 1, 4);
-		String[] dates = ProjectUtils.getAllDatesWithinGivenRangeAndOffset(1, 4);
+		String[] dates = ProjectUtils.getAllDatesWithinGivenRangeAndOffset(2, 4);
 		event.setStartDate(dates[0]);
 		event.setEndDate(dates[3]);
 		TicketType atSpecificType = event.getTicketTypes().stream()
-				.filter(tt -> tt.getAdditionalOptions().getSaleStart().equals(SaleStart.AT_SPECIFIC_TIME)).findFirst()
+				.filter(tt -> tt.getAdditionalOptions().getSaleStart().equals(SaleStart.AT_SPECIFIC_TIME)
+						&& tt.getAdditionalOptions().getSaleEnd().equals(SaleEnd.AT_SPECIFIC_TIME)).findFirst()
 				.get();
 		atSpecificType.getAdditionalOptions().setStartSaleDate(dates[1]);
+		atSpecificType.getAdditionalOptions().setEndSaleDate(dates[1]);
 		return new Object[][] { { superuser, event } };
 
 	}

--- a/selenium/qa/src/test/resources/conf/beta_test_data.json
+++ b/selenium/qa/src/test/resources/conf/beta_test_data.json
@@ -163,7 +163,12 @@
 						"label": "At a specific time",
 						"value": "custom"
 					},
-					"start_sale_time": "07:00 AM"
+					"start_sale_time": "09:00 AM",
+					"sale_end": {
+						"label": "At a specific time",
+						"value": "custom"
+					},
+					"end_sale_time": "10:30 AM"
 				}
 			},
 			{
@@ -175,7 +180,7 @@
 						"label": "When sales end for...",
 						"value": "parent"
 					},
-					"start_sale_ticket_type": "GA"
+					"start_sale_ticket_type": "VIP"					
 				}
 			}
 		]

--- a/selenium/qa/src/test/resources/conf/develop_test_data.json
+++ b/selenium/qa/src/test/resources/conf/develop_test_data.json
@@ -164,7 +164,12 @@
 						"label": "At a specific time",
 						"value": "custom"
 					},
-					"start_sale_time": "07:00 AM"
+					"start_sale_time": "09:00 AM",
+					"sale_end": {
+						"label": "At a specific time",
+						"value": "custom"
+					},
+					"end_sale_time": "10:30 AM"
 				}
 			},
 			{
@@ -176,7 +181,7 @@
 						"label": "When sales end for...",
 						"value": "parent"
 					},
-					"start_sale_ticket_type": "GA"
+					"start_sale_ticket_type": "VIP"
 				}
 			}
 		]


### PR DESCRIPTION
### References Issues:

### Description:
created new profile in maven to execute tests,  (hub profile)
new execution command is
` mvn clean verify -P hub -Dhuburl=http://hub_host:hub_port/wd/hub -Dbaseurl=base_url`
this will execute `testng.xml` suite file located in` selenium/qa/config/hub/` folder.
Modified docker-compose file a bit. There is no need to start executing tests as separate docker compose service for each browser. That is already handled by testng, through` testng.xml` and files it references That way some degree of parallel execution can be achieved. However if it is a requirement, some modification can be done to do that.

To ensure that tests base code is updated each time the docker-compose is run, and tear down of containers was not executed from previous runs. We can run
`docker-compose -f <file_name> up --build test`
`--build test `will rebuild the test service, copy the new base code, but any maven dependencies will stay cached in docker container from previous run

Also added to that profile execution, new maven plugin `maven-postman-plugin` that sends test report to given receiver. It requires following configuration.
`From Email address` 
`<from></from>`
host data 
`<mailhost>smtp.mail_host.com</mailhost> `  
`<mailport>465</mailport>` 
`<mailssl>true</mailssl>` 
`<mailAltConfig>true</mailAltConfig>` 
Email Authentication(Username and Password)
`<mailuser></mailuser>` 
`<mailpassword></mailpassword>`
`<receivers>`
  `      <receiver>receiver_test@test.com</receiver>`
`</receivers>`

Currently this plugin is commented out, can be enabled once host data and receiver list is entered. 
Also commented out is code in docket compose file for different browser services, it will be removed once agreed we don't need it anymore

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
