### PR TITLE
Boxoffice report pdf font fix

### DIFF
--- a/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
+++ b/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
@@ -228,7 +228,7 @@ class BoxOfficeSalesSummary extends Component {
 	}
 
 	renderOperators() {
-		const { classes } = this.props;
+		const { classes, printVersion } = this.props;
 		const { operators } = this.state;
 
 		if (!operators) {
@@ -242,7 +242,7 @@ class BoxOfficeSalesSummary extends Component {
 						<Typography className={classes.tableHeading}>
 							Operator: {operator.operator_name}
 						</Typography>
-						<OperatorTable {...operator}/>
+						<OperatorTable {...operator} printVersion={printVersion}/>
 					</React.Fragment>
 				))}
 			</React.Fragment>

--- a/src/components/pages/admin/reports/boxOfficeSalesSummary/OperatorTable.js
+++ b/src/components/pages/admin/reports/boxOfficeSalesSummary/OperatorTable.js
@@ -14,7 +14,7 @@ const styles = theme => {
 };
 
 const OperatorTable = props => {
-	const { classes, payments, events } = props;
+	const { classes, payments, events, printVersion } = props;
 	const columnStyles = [
 		{ flex: 4 },
 		{ flex: 3 },
@@ -55,7 +55,11 @@ const OperatorTable = props => {
 
 				return (
 					<div key={index}>
-						<TableRow columnStyles={columnStyles} gray={!!(index % 2)}>
+						<TableRow
+							columnStyles={columnStyles}
+							gray={!!(index % 2)}
+							printVersion={printVersion}
+						>
 							{[
 								event_name,
 								event_date,
@@ -79,6 +83,7 @@ const OperatorTable = props => {
 							subTotal1={payment_type === "Cash"}
 							subTotal2={payment_type === "CreditCard"}
 							gray={payment_type !== "Cash" && payment_type !== "CreditCard"}
+							printVersion={printVersion}
 						>
 							{[
 								payment_type,
@@ -93,7 +98,7 @@ const OperatorTable = props => {
 				);
 			})}
 
-			<TableRow columnStyles={columnStyles} total>
+			<TableRow columnStyles={columnStyles} total printVersion={printVersion}>
 				{[
 					"Operator total",
 					"",
@@ -111,7 +116,8 @@ OperatorTable.propTypes = {
 	classes: PropTypes.object.isRequired,
 	operator_name: PropTypes.string.isRequired,
 	payments: PropTypes.array.isRequired,
-	events: PropTypes.array.isRequired
+	events: PropTypes.array.isRequired,
+	printVersion: PropTypes.bool
 };
 
 export default withStyles(styles)(OperatorTable);

--- a/src/components/pages/admin/reports/boxOfficeSalesSummary/TableRow.js
+++ b/src/components/pages/admin/reports/boxOfficeSalesSummary/TableRow.js
@@ -45,6 +45,9 @@ const styles = theme => {
 		text: {
 			fontSize: theme.typography.fontSize
 		},
+		printText: {
+			fontSize: theme.typography.fontSize * 0.8
+		},
 		subTotal1: {
 			backgroundColor: "#a6becd"
 		},
@@ -65,6 +68,7 @@ const TableRow = props => {
 		children,
 		classes,
 		total,
+		printVersion,
 		...rest
 	} = props;
 
@@ -75,8 +79,9 @@ const TableRow = props => {
 				className={classNames({
 					[classes.headingText]: heading || subTotal1 || subTotal2,
 					[classes.subHeading]: subHeading,
-					[classes.text]: !heading,
-					[classes.totalText]: total
+					[classes.text]: !printVersion && !heading,
+					[classes.totalText]: total,
+					[classes.printText]: printVersion
 				})}
 				key={index}
 				style={columnStyles[index]}
@@ -113,7 +118,8 @@ TableRow.propTypes = {
 	subTotal1: PropTypes.bool,
 	subTotal2: PropTypes.bool,
 	heading: PropTypes.bool,
-	subHeading: PropTypes.bool
+	subHeading: PropTypes.bool,
+	printVersion: PropTypes.bool
 };
 
 export default withStyles(styles)(TableRow);


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1132088822459437

### Description:
Using smaller font size for exported PDFs so it doesn't cut off the date field.

### Release Screenshots / Video:
[Box office sales summary.pdf](https://github.com/big-neon/bn-web/files/3749952/Box.office.sales.summary.pdf)

### Environment Variables:
 * No change

### API requirements:
