### PR TITLE
Using event_end when it's added to the api

### DIFF
--- a/src/components/pages/admin/reports/settlement/SettlementReport.js
+++ b/src/components/pages/admin/reports/settlement/SettlementReport.js
@@ -162,6 +162,12 @@ class SettlementReport extends Component {
 						.utc(event.event_start)
 						.tz(organizationTimezone)
 						.format(dateFormatNoTimezone);
+					event.displayEndTime = !event.event_end
+						? "-"
+						: moment
+							.utc(event.event_end)
+							.tz(organizationTimezone)
+							.format(dateFormatNoTimezone);
 				});
 
 				const eventList = event_entries.map(({ event }) => event);


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1138868228851596/1132788783646657/f

### Description:
Adds missing end date that'll appear after the API has been adjusted.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
