### PR TITLE
Report fixes 3

### DIFF
--- a/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
+++ b/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
@@ -303,6 +303,7 @@ class BoxOfficeSalesSummary extends Component {
 					</Typography>
 				) : null}
 				<ReportsDate
+					defaultStartTimeBeforeNow={{ value: 0, unit: "d" }}
 					timezone={organizationTimezone}
 					onChange={this.refreshData.bind(this)}
 				/>

--- a/src/components/pages/admin/reports/settlement/EventListTable.js
+++ b/src/components/pages/admin/reports/settlement/EventListTable.js
@@ -33,7 +33,6 @@ const EventListTable = props => {
 			<TotalsRow columnStyles={columnStyles} heading>
 				{[
 					"Event start Date/Time",
-					"Event End Date/Time",
 					"Venue",
 					"Event Name"
 				]}
@@ -41,7 +40,7 @@ const EventListTable = props => {
 
 			{eventList
 				? eventList.map((event, index) => {
-					const { id, displayEndTime, displayStartTime, venue, name } = event;
+					const { id, displayStartTime, venue, name } = event;
 					const even = index % 2 === 0;
 
 					return (
@@ -51,7 +50,7 @@ const EventListTable = props => {
 							darkGray={!even}
 							columnStyles={columnStyles}
 						>
-							{[displayStartTime, displayEndTime, venue.name, name]}
+							{[displayStartTime, venue.name, name]}
 						</TotalsRow>
 					);
 				  })

--- a/src/components/pages/admin/reports/settlement/SettlementReport.js
+++ b/src/components/pages/admin/reports/settlement/SettlementReport.js
@@ -94,6 +94,7 @@ class SettlementReport extends Component {
 				const { organizationTimezone } = this.props;
 
 				const dateFormat = "MMM D, YYYY z";
+				const dateTimeFormat = "MMM D, YYYY, h:mm A";
 				const dateFormatNoTimezone = "MMM D, YYYY";
 
 				const displayDateRange = `${moment
@@ -161,13 +162,7 @@ class SettlementReport extends Component {
 					event.displayStartTime = moment
 						.utc(event.event_start)
 						.tz(organizationTimezone)
-						.format(dateFormatNoTimezone);
-					event.displayEndTime = !event.event_end
-						? "-"
-						: moment
-							.utc(event.event_end)
-							.tz(organizationTimezone)
-							.format(dateFormatNoTimezone);
+						.format(dateTimeFormat);
 				});
 
 				const eventList = event_entries.map(({ event }) => event);
@@ -289,8 +284,8 @@ class SettlementReport extends Component {
 		]);
 
 		eventList.forEach(event => {
-			const { displayEndTime, displayStartTime, venue, name } = event;
-			csvRows.push([displayStartTime, displayEndTime, venue.name, name]);
+			const { displayStartTime, venue, name } = event;
+			csvRows.push([displayStartTime, venue.name, name]);
 		});
 
 		csvRows.push([]);


### PR DESCRIPTION
### References Issues:

### Description:
- Settlement report change event start to include time
- Remove event end date from settlement report
- Box office office sales report default date range to today

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
