### PR TITLE
automated test, docker execution

### DIFF
--- a/selenium/qa/docker-compose.yml
+++ b/selenium/qa/docker-compose.yml
@@ -46,33 +46,40 @@ services:
     depends_on:
       - chrome
       - firefox
+    volumes:
+      - /usr/src/selenium:/usr/src/report
+      - /usr/src/maven:/root/.m2
     environment:
       - HUB_HOST=selenium-hub
       - HUB_PORT=4444
       - BASE_URL=https://develop.bigneon.com
+
+  test-chrome:
+    build:
+      context: .
+      dockerfile: local.Dockerfile
+    depends_on:
+      - chrome
+    volumes:
+      - /usr/src/selenium:/usr/src/report
+      - /usr/src/maven:/root/.m2
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+      - BASE_URL=https://develop.bigneon.com
+      - CONFIG=chrome.suite.conf.json
       
-#  test-chrome:
-#    build: ./
-#    depends_on:
-#      - chrome
-#    environment:
-#      - HUB_HOST=selenium-hub
-#      - HUB_PORT=4444
-
-#  test-firefox:
-#    build: ./
-#    depends_on:
-#     - firefox
-#    environment:
-#     - HUB_HOST=selenium-hub
-#     - HUB_PORT=4444
-#     - BASE_URL=https://develop.bigneon.com
-
-#  test-chrome-debug:
-#    build: ./
-#    depends_on:
-#      - chrome-debug
-#    environment:
-#      - HUB_HOST=selenium-hub
-#      - HUB_PORT=4444
-#      - BASE_URL=https://develop.bigneon.com
+  test-firefox:
+    build: 
+      context: .
+      dockerfile: local.Dockerfile
+    depends_on:
+      - firefox
+    volumes:
+      - /usr/src/selenium:/usr/src/report
+      - /usr/src/maven:/root/.m2
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444
+      - BASE_URL=https://develop.bigneon.com
+      - CONFIG=firefox.suite.conf.json

--- a/selenium/qa/extra/docker_scripts/start_hub_profile.sh
+++ b/selenium/qa/extra/docker_scripts/start_hub_profile.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mvn clean verify -P hub -Dhuburl=http://"$HUB_HOST":"$HUB_PORT"/wd/hub -Dbaseurl=$BASE_URL -Dserverauthname=$USERNAME -Dserverauthpass=$PASS
+cp target/failsafe-reports/emailable-report.html /usr/src/report/

--- a/selenium/qa/extra/docker_scripts/start_local.sh
+++ b/selenium/qa/extra/docker_scripts/start_local.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mvn clean verify -Dhuburl=http://"$HUB_HOST":"$HUB_PORT"/wd/hub -Dconfig=$CONFIG -Dbaseurl=$BASE_URL -Dbrowser=hub -Dbaseurl=$BASE_URL -Dserverauthname=$USERNAME -Dserverauthpass=$PASS
+cp target/failsafe-reports/emailable-report.html /usr/src/report/

--- a/selenium/qa/local.Dockerfile
+++ b/selenium/qa/local.Dockerfile
@@ -5,9 +5,8 @@ RUN mkdir report
 WORKDIR /usr/src/test
 COPY pom.xml .
 RUN mvn dependency:resolve
-WORKDIR /usr/src/test
 COPY src ./src/
 COPY config ./config/
-COPY /extra/docker_scripts/start_hub_profile.sh .
-RUN chmod +x start_hub_profile.sh
-CMD ["./start_hub_profile.sh"]
+COPY /extra/docker_scripts/start_local.sh .
+RUN chmod +x start_local.sh
+CMD ["./start_local.sh"]

--- a/selenium/qa/src/test/java/config/HubRemoteDriverManager.java
+++ b/selenium/qa/src/test/java/config/HubRemoteDriverManager.java
@@ -1,8 +1,14 @@
 package config;
 
+import java.io.FileReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -30,7 +36,19 @@ public class HubRemoteDriverManager extends DriverManager {
 	
 	public RemoteWebDriver createRemoteWebDriver(String config_file, String environment) throws Exception {
 		DesiredCapabilities capabilities = new DesiredCapabilities();
-		capabilities.setBrowserName(environment);
+		if (config_file != null && !config_file.isEmpty()) {
+			JSONParser parser = new JSONParser();
+			JSONObject config = (JSONObject) parser.parse(new FileReader("src/test/resources/conf/hub/"+ config_file));
+			JSONObject envs = (JSONObject) config.get("environments");
+	        Iterator it = envs.entrySet().iterator();
+	        while (it.hasNext()) {
+	            Map.Entry<String, String> pair = (Entry<String, String>) it.next();
+	            System.out.println(pair.getKey()+ " " + pair.getValue());
+	            capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+	        }
+		} else {
+			capabilities.setBrowserName(environment);
+		}
 		return new RemoteWebDriver(new URL(this.url), capabilities);
 	}
 

--- a/selenium/qa/src/test/resources/conf/hub/chrome.suite.conf.json
+++ b/selenium/qa/src/test/resources/conf/hub/chrome.suite.conf.json
@@ -1,0 +1,5 @@
+{
+	"environments" : {
+		"browserName": "chrome"
+	}
+}

--- a/selenium/qa/src/test/resources/conf/hub/firefox.suite.conf.json
+++ b/selenium/qa/src/test/resources/conf/hub/firefox.suite.conf.json
@@ -1,0 +1,5 @@
+{
+	"environments" : {
+		"browserName": "firefox"
+	}
+}


### PR DESCRIPTION
### References Issues:

### Description:
maven command for test execution is located in start_.... .sh file.
Two different commands are(files) are needed to because when executing test on both chrome and firefox maven profile -P hub is used, that uses` /config.hub.testng.xml` suite file
And if we want to execute just one browser no profile is needed and `/config/local/testng.xml` file is used.
That is why there are three docker-compose services:
- one for testing on both browsers, where some test are run in parallel. `docker-compose up --build test`
- on firefox , `docker-compose up --build test-firefox`
- on chrome ,` docker-compose up --build test-chrome`

Each of mentioned servces  uses HubRemoteDriverManger class

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
