### PR TITLE
Event summary report fee fix

### DIFF
--- a/src/components/pages/admin/reports/eventAudit/Audit.js
+++ b/src/components/pages/admin/reports/eventAudit/Audit.js
@@ -121,8 +121,7 @@ class Audit extends Component {
 
 	renderTicketCounts() {
 		const { eventId, classes } = this.props;
-
-		const eventData = ticketCountReport.dataByTicketPricing[eventId];
+		const eventData = ticketCountReport.dataByPrice[eventId];
 		if (!eventData) {
 			return <Typography>No counts...</Typography>;
 		}

--- a/src/components/pages/admin/reports/eventSummary/EventSummary.js
+++ b/src/components/pages/admin/reports/eventSummary/EventSummary.js
@@ -58,7 +58,7 @@ class EventSummary extends Component {
 		const { eventId } = this.props;
 		downloadCSV(
 			summaryReport.csv(
-				summaryReport.dataByPrice[eventId],
+				eventId,
 				summaryReport.feesData[eventId]
 			),
 			"event-summary-report"
@@ -97,7 +97,7 @@ class EventSummary extends Component {
 
 	renderRevenueShare() {
 		const { eventId, classes } = this.props;
-		const eventSales = summaryReport.dataByPrice[eventId];
+		const eventSales = summaryReport.dataByPriceAndFee[eventId];
 		const eventFees = summaryReport.feesData[eventId];
 		if (eventSales === false) {
 			//Query failed
@@ -143,12 +143,14 @@ class EventSummary extends Component {
 								]}
 							</EventSummaryRow>
 
-							{sales.map((pricePoint, priceIndex) => {
+							{sales.filter(function(pricePoint) {
+    							return pricePoint.online_fee_count > 0;
+  						}).map((pricePoint, priceIndex) => {
 								const {
 									ticket_pricing_price_in_cents,
 									promo_code_discounted_ticket_price,
 									client_online_fees_in_cents,
-									online_sale_count,
+									online_fee_count,
 									ticket_pricing_name,
 									hold_name,
 									promo_redemption_code
@@ -164,9 +166,8 @@ class EventSummary extends Component {
 								const priceInCents =
 									ticket_pricing_price_in_cents +
 									promo_code_discounted_ticket_price;
-
 								const clientFeesPerSale =
-									client_online_fees_in_cents / online_sale_count;
+									client_online_fees_in_cents / online_fee_count;
 
 								return (
 									<EventSummaryRow key={priceIndex}>
@@ -174,7 +175,7 @@ class EventSummary extends Component {
 											rowName,
 											dollars(priceInCents),
 											dollars(clientFeesPerSale),
-											online_sale_count,
+											online_fee_count,
 											" ",
 											" ",
 											dollars(client_online_fees_in_cents)

--- a/src/stores/reports/summaryReport.js
+++ b/src/stores/reports/summaryReport.js
@@ -12,8 +12,9 @@ export class SummaryReport extends TicketCountReport {
 		super.fetchCountAndSalesData(queryParams, false, onSuccess);
 	}
 
-	csv(eventData, eventFees) {
+	csv(eventId, eventFees) {
 		let csvRows = [];
+		const eventData = super.dataByPrice[eventId];
 		const { eventName } = eventData;
 		let title = "Event summary report";
 		if (eventName) {
@@ -29,7 +30,7 @@ export class SummaryReport extends TicketCountReport {
 		csvRows.push([""]);
 
 		//Revenue share
-		csvRows = [...csvRows, ...this.revenueShareCsvData(eventData, eventFees)];
+		csvRows = [...csvRows, ...this.revenueShareCsvData(super.dataByPriceAndFee[eventId], eventFees)];
 		return csvRows;
 	}
 
@@ -43,7 +44,9 @@ export class SummaryReport extends TicketCountReport {
 			const ticketSale = eventData.tickets[ticketId];
 			const { totals, sales, name } = ticketSale;
 
-			sales.forEach((pricePoint, priceIndex) => {
+			sales.filter(function(pricePoint) {
+				return pricePoint.online_fee_count > 0;
+			}).forEach((pricePoint, priceIndex) => {
 				let priceName = pricePoint.ticket_pricing_name;
 				if (pricePoint.hold_name) {
 					priceName =
@@ -59,7 +62,7 @@ export class SummaryReport extends TicketCountReport {
 					`${name} - ${priceName}`,
 					dollars(priceInCents),
 					dollars(pricePoint.client_online_fees_in_cents),
-					pricePoint.online_sale_count,
+					pricePoint.online_fee_count,
 					" ",
 					" ",
 					dollars(pricePoint.client_online_fees_in_cents)

--- a/src/stores/reports/ticketCountReport.js
+++ b/src/stores/reports/ticketCountReport.js
@@ -272,6 +272,15 @@ export class TicketCountReport {
 
 	@computed
 	get dataByPrice() {
+		return this.fetchData(false);
+	}
+
+	@computed
+	get dataByPriceAndFee() {
+		return this.fetchData(true);
+	}
+
+	fetchData(groupFees) {
 		//Need to break the link from the dataByTicketPricing Observable
 		const allEventData = JSON.parse(JSON.stringify(this.dataByTicketPricing));
 		const groupByPriceTallyKeys = [
@@ -300,11 +309,10 @@ export class TicketCountReport {
 				const tmpGroupByPrice = {};
 
 				ticketSalesPricing.forEach(row => {
-					//Group by price, but if there's a hold_id, group by that as well
+					//Group by price and fees, but if there's a hold_id, group by that as well
 					const groupingKey = `pricekey-${row.ticket_pricing_price_in_cents +
-						row.promo_code_discounted_ticket_price}${
-						row.hold_id ? `-hold-${row.hold_id}` : ""
-					}`;
+						row.promo_code_discounted_ticket_price}
+					${groupFees ? `-fees-${row.client_online_fees_in_cents}` : ""}${row.hold_id ? `-hold-${row.hold_id}` : ""}`;
 
 					//const ticketPricingPriceInCents = row.ticket_pricing_price_in_cents;
 					if (!tmpGroupByPrice.hasOwnProperty(groupingKey)) {


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1145151428687738/1145455742825753

### Description:
See https://github.com/big-neon/bn-api/pull/1568

Let me know if this isn't an ideal way to accomplish this. Modified the API to return separate sales rows per client fee as it's grouped on that now. This allows the frontend to either group by sales as it was doing previously or by sales and the fee to further break out the data.

### Release Screenshots / Video:
See example in PR https://github.com/big-neon/bn-api/pull/1568

### Environment Variables:
 * No change

### API requirements:
https://github.com/big-neon/bn-api/pull/1568
