### PR TITLE
Fix transfer activities to show action involved instead of current status on cards

### DIFF
--- a/src/components/pages/admin/fans/FanHistoryActivityCard.js
+++ b/src/components/pages/admin/fans/FanHistoryActivityCard.js
@@ -158,6 +158,7 @@ class FanHistoryActivityCard extends Component {
 		const {
 			ticket_quantity,
 			order_number,
+			action,
 			status,
 			total_in_cents,
 			ticket_ids,
@@ -667,11 +668,11 @@ class FanHistoryActivityCard extends Component {
 						<Card variant={"subCard"} className={classes.card}>
 							<div>
 								<FanActivityCardRow>
-									{status === "Cancelled" ? (
+									{action === "Cancelled" ? (
 										<img
 											src={servedImage("/icons/transfer-circle-error.svg")}
 										/>
-									) : status === "Completed" ? (
+									) : action === "Accepted" ? (
 										<img
 											src={servedImage("/icons/transfer-circle-success.svg")}
 										/>
@@ -693,7 +694,7 @@ class FanHistoryActivityCard extends Component {
 											{profile.first_name}&nbsp;{profile.last_name}&nbsp;
 										</span>
 										<span className={classes.boldSpan}>
-											transferred ({status})&nbsp;
+											transferred ({action})&nbsp;
 										</span>
 										{ticket_ids.length > 1 ? (
 											<span>{ticket_ids.length} tickets to </span>
@@ -731,7 +732,7 @@ class FanHistoryActivityCard extends Component {
 												Transfer Address:
 											</Typography>
 											<Typography className={classes.greySubtitleCap}>
-												{status === "Cancelled"
+												{action === "Cancelled"
 													? "Cancelled by"
 													: "Accepted by"}
 											</Typography>
@@ -775,7 +776,7 @@ class FanHistoryActivityCard extends Component {
 												{destination_addresses}
 											</Typography>
 											<Typography className={classes.darkGreySubtitle}>
-												{status === "Cancelled" ? (
+												{action === "Cancelled" ? (
 													cancelled_by ? (
 														<span className={classes.pinkSpan}>
 															{cancelled_by.full_name} <br/>
@@ -830,6 +831,7 @@ class FanHistoryActivityCard extends Component {
 		const {
 			ticket_quantity,
 			order_number,
+			action,
 			status,
 			total_in_cents,
 			ticket_ids,
@@ -1340,12 +1342,12 @@ class FanHistoryActivityCard extends Component {
 						<div className={classes.mobileActivityHeader}>
 							<div>
 								<div className={classes.mobileHeaderTopRow}>
-									{status === "Cancelled" ? (
+									{action === "Cancelled" ? (
 										<img
 											className={classes.mobiIcon}
 											src={servedImage("/icons/transfer-circle-error.svg")}
 										/>
-									) : status === "Completed" ? (
+									) : action === "Accepted" ? (
 										<img
 											className={classes.mobiIcon}
 											src={servedImage("/icons/transfer-circle-success.svg")}
@@ -1367,7 +1369,7 @@ class FanHistoryActivityCard extends Component {
 											&nbsp;
 										</span>
 										<span className={classes.boldSpan}>
-											transferred ({status})&nbsp;
+											transferred ({action})&nbsp;
 										</span>
 										{ticket_ids.length > 1 ? (
 											<span>{ticket_ids.length} tickets to </span>
@@ -1443,12 +1445,12 @@ class FanHistoryActivityCard extends Component {
 											</div>
 											<div className={classes.halfFlexItem}>
 												<Typography className={classes.greySubtitleCap}>
-													{status === "Cancelled"
+													{action === "Cancelled"
 														? "Cancelled by"
 														: "Accepted by"}
 												</Typography>
 												<Typography className={classes.darkGreySubtitle}>
-													{status === "Cancelled" ? (
+													{action === "Cancelled" ? (
 														cancelled_by ? (
 															<span className={classes.pinkSpan}>
 																{cancelled_by.full_name} <br/>


### PR DESCRIPTION
# References Issues:
https://app.asana.com/0/1145151428687738/1126136784275287

### Description:
It looks like the transfer activity cards are always using the 'status' of the transfer. This is the current status of it to allow for things like rendering a 'Cancel' button or the like. There's a separate 'action' which includes one of 'Started', 'Accepted', or 'Cancelled' which indicates the action involved that triggered the activity card. This PR is just to change to use that where possible for the rendering.

Noticed the issue while handling the associated API PR. Pushing up a fix here since it seems straightforward.

### Release Screenshots / Video:
Without fixes:
![Screen Shot 2019-11-11 at 2 29 22 PM](https://user-images.githubusercontent.com/1319304/68616431-04798d80-0493-11ea-8f0f-83d4d40e0e1b.png)

With fixes:
![Screen Shot 2019-11-11 at 2 48 30 PM](https://user-images.githubusercontent.com/1319304/68616430-04798d80-0493-11ea-96ac-e3f77b6d9ce5.png)

Individual cards:
![Screen Shot 2019-11-11 at 2 54 44 PM](https://user-images.githubusercontent.com/1319304/68616544-41458480-0493-11ea-8b9d-6e8c8b92c7c9.png)
![Screen Shot 2019-11-11 at 2 54 39 PM](https://user-images.githubusercontent.com/1319304/68616545-41458480-0493-11ea-8563-60da01a77db6.png)
![Screen Shot 2019-11-11 at 2 54 33 PM](https://user-images.githubusercontent.com/1319304/68616547-41458480-0493-11ea-8d78-2c3b1a8096ec.png)


### Environment Variables:
 * No change

### API requirements:
https://github.com/big-neon/bn-api/pull/1572 related but not required