### PR TITLE
Using end date for report range instead of created at date

### DIFF
--- a/src/components/pages/admin/reports/settlement/AdjustmentsList.js
+++ b/src/components/pages/admin/reports/settlement/AdjustmentsList.js
@@ -52,12 +52,11 @@ const AdjustmentsList = props => {
 							- {displayCreatedAt}
 						</Typography>
 						<Typography className={classes.text}>
-							<span className={classes.boldText}>Value:</span>{" "}
-							{dollars(amount_in_cents)}
+							Value: {dollars(amount_in_cents)}
 						</Typography>
 
 						<Typography className={classes.text}>
-							<span className={classes.boldText}>Note:</span> {note || "-"}
+							Note: {note || "-"}
 						</Typography>
 					</div>
 				);

--- a/src/components/pages/admin/reports/settlement/SettlementReport.js
+++ b/src/components/pages/admin/reports/settlement/SettlementReport.js
@@ -98,13 +98,17 @@ class SettlementReport extends Component {
 				const dateFormat = "MMM D, YYYY";
 				const dateTimeFormat = "MMM D, YYYY, h:mm A z";
 
-				const displayDateRange = `${moment
-					.utc(start_time)
-					.tz(organizationTimezone)
-					.format(dateFormat)} to ${moment
-					.utc(end_time)
-					.tz(organizationTimezone)
-					.format(dateFormat)}`;
+				const startDate = moment.utc(start_time).tz(organizationTimezone);
+				const endDate = moment.utc(end_time).tz(organizationTimezone);
+
+				//Back one day if needed for display
+				if (startDate.diff(endDate, "days") > 1) {
+					endDate.add("d", -1);
+				}
+
+				const displayDateRange = `${startDate.format(
+					dateFormat
+				)} to ${endDate.format(dateFormat)}`;
 
 				let adjustmentsInCents = 0;
 				let totalFaceInCents = 0;

--- a/src/components/pages/admin/reports/settlement/SettlementReportList.js
+++ b/src/components/pages/admin/reports/settlement/SettlementReportList.js
@@ -53,27 +53,39 @@ class SettlementReportList extends Component {
 				const { data, paging } = response.data; //TODO pagination
 				const reports = [];
 
-				data.forEach(({ created_at, start_time, end_time, only_finished_events, ...rest }) => {
-					const displayDateRange = `${moment
-						.utc(start_time)
-						.tz(organizationTimezone)
-						.format(rangeDateFormat)} to ${moment
-						.utc(end_time)
-						.tz(organizationTimezone)
-						.format(rangeDateFormat)}`;
+				data.forEach(
+					({
+						created_at,
+						start_time,
+						end_time,
+						only_finished_events,
+						...rest
+					}) => {
+						const startDate = moment.utc(start_time).tz(organizationTimezone);
+						const endDate = moment.utc(end_time).tz(organizationTimezone);
 
-					const createdAtMoment = moment
-						.utc(created_at)
-						.tz(organizationTimezone);
+						//Back one day if needed for display
+						if (startDate.diff(endDate, "days") > 1) {
+							endDate.add("d", -1);
+						}
 
-					reports.push({
-						...rest,
-						createdAtMoment,
-						displayCreatedAt: createdAtMoment.format(dateFormat),
-						displayDateRange,
-						isPostEventSettlement: only_finished_events
-					});
-				});
+						const displayDateRange = `${startDate.format(
+							rangeDateFormat
+						)} to ${endDate.format(rangeDateFormat)}`;
+
+						// const createdAtMoment = moment
+						// 	.utc(created_at)
+						// 	.tz(organizationTimezone);
+
+						reports.push({
+							...rest,
+							createdAtMoment: endDate, //Order by the date the report ends for
+							displayCreatedAt: endDate.format(dateFormat),
+							displayDateRange,
+							isPostEventSettlement: only_finished_events
+						});
+					}
+				);
 
 				reports.sort((a, b) => {
 					if (a.createdAtMoment.diff(b.createdAtMoment) < 0) {


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1149047845558135/1149907075826105

### Description:
- Instead of displaying the created at date for a report, use the end date for the report range.
- Move end date one day back if required. i.e. Report range becomes Monday to Sunday

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
