### PR TITLE
Defaulting ticket purchase limit to 10

### DIFF
--- a/src/stores/eventUpdate.js
+++ b/src/stores/eventUpdate.js
@@ -170,7 +170,7 @@ class EventUpdate {
 			capacity: "",
 			priceAtDoor: "",
 			increment: 1,
-			limitPerPerson: undefined,
+			limitPerPerson: 10,
 			price_in_cents: "",
 			visibility: "Always",
 			//By default the server will create a Default ticket price point, anything additional added to this array is an override.


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1149047845558135/1142660275386601

### Description:
Defaulting ticket purchase limit to 10 for ticket types

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
