### PR TITLE
Sort pricing on load instead of in render method

### DIFF
--- a/src/components/pages/admin/events/updateSections/TicketType.js
+++ b/src/components/pages/admin/events/updateSections/TicketType.js
@@ -860,48 +860,36 @@ const TicketDetails = observer(props => {
 				) : null}
 
 				<Collapse in={!!showPricing}>
-					{pricing
-						.slice()
-						.sort((a, b) => {
-							return a.startDate < b.startDate
-								? -1
-								: a.startDate > b.startDate
-									? 1
-									: 0;
-						})
-						.map((pricePoint, pricePointIndex) => {
-							return (
-								<div key={pricePointIndex}>
-									<FormHeading className={classes.title}>
-										Scheduled price change {pricePointIndex + 1}
-									</FormHeading>
-									<PricePoint
-										isCancelled={isCancelled}
-										updatePricePointDetails={pricePointDetails => {
-											const updatedPricePoint = {
-												...pricePoint,
-												...pricePointDetails
-											};
-											const updatedPricing = pricing;
-											updatedPricing[pricePointIndex] = updatedPricePoint;
+					{pricing.map((pricePoint, pricePointIndex) => {
+						return (
+							<div key={pricePointIndex}>
+								<FormHeading className={classes.title}>
+									Scheduled price change {pricePointIndex + 1}
+								</FormHeading>
+								<PricePoint
+									isCancelled={isCancelled}
+									updatePricePointDetails={pricePointDetails => {
+										const updatedPricePoint = {
+											...pricePoint,
+											...pricePointDetails
+										};
+										const updatedPricing = pricing;
+										updatedPricing[pricePointIndex] = updatedPricePoint;
 
-											updateTicketType(index, {
-												pricing: updatedPricing
-											});
-										}}
-										errors={pricingErrors[pricePointIndex] || {}}
-										validateFields={validateFields}
-										onDelete={() =>
-											eventUpdateStore.removeTicketPricing(
-												index,
-												pricePointIndex
-											)
-										}
-										{...pricePoint}
-									/>
-								</div>
-							);
-						})}
+										updateTicketType(index, {
+											pricing: updatedPricing
+										});
+									}}
+									errors={pricingErrors[pricePointIndex] || {}}
+									validateFields={validateFields}
+									onDelete={() =>
+										eventUpdateStore.removeTicketPricing(index, pricePointIndex)
+									}
+									{...pricePoint}
+								/>
+							</div>
+						);
+					})}
 					{!isCancelled ? (
 						<Button
 							variant="additional"

--- a/src/components/pages/admin/events/updateSections/Tickets.js
+++ b/src/components/pages/admin/events/updateSections/Tickets.js
@@ -202,7 +202,7 @@ const formatForInput = (ticket_types, event) => {
 			box_office_sales_enabled
 		} = ticket_type;
 
-		const pricing = [];
+		let pricing = [];
 		const priceAtDoor = "";
 		ticket_pricing.forEach(pricePoint => {
 			const { name, price_in_cents } = pricePoint;
@@ -270,6 +270,10 @@ const formatForInput = (ticket_types, event) => {
 			additionalFeeInDollars = `${(additional_fee_in_cents / 100).toFixed(2)}`;
 			showAdditionalFee = true;
 		}
+
+		pricing = pricing.slice().sort((a, b) => {
+			return a.startDate < b.startDate ? -1 : a.startDate > b.startDate ? 1 : 0;
+		});
 
 		const ticketType = {
 			id,


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1151234524692625/1152880367597697

### Description:
Price schedules were being sorted in the render causing them to jump and switch places without the user knowing. This change just sorts on the first time the price schedules are loaded.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
