### PR TITLE
Keeping the date range in PDF exports for reports

### DIFF
--- a/src/components/pages/admin/reports/ExportPDF.js
+++ b/src/components/pages/admin/reports/ExportPDF.js
@@ -141,7 +141,8 @@ class ExportPDF extends Component {
 		const event_id = getUrlParam("event_id");
 		const settlement_id = getUrlParam("settlement_id");
 		const type = getUrlParam("type");
-
+		const start_utc = getUrlParam("start_utc");
+		const end_utc = getUrlParam("end_utc");
 		const reportType = reportTypes[type];
 
 		if (!reportType) {
@@ -194,9 +195,12 @@ class ExportPDF extends Component {
 					organizationTimezone={organizationTimezone}
 					eventId={event_id}
 					printVersion
+					startUtc={start_utc}
+					endUtc={end_utc}
 					onLoad={this.onReportLoad}
 					venueTimeZone={venueTimeZone}
 					settlementId={settlement_id}
+					isPDFExport={true}
 				/>
 			</div>
 		);

--- a/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
+++ b/src/components/pages/admin/reports/boxOfficeSalesSummary/BoxOfficeSalesSummary.js
@@ -156,19 +156,32 @@ class BoxOfficeSalesSummary extends Component {
 		downloadCSV(csvRows, "box-office-sales-summary");
 	}
 
-	refreshData(
-		dataParams = {
-			start_utc: null,
-			end_utc: null,
-			startDate: null,
-			endDate: null
-		}
-	) {
-		const { startDate, endDate, start_utc, end_utc } = dataParams;
+	updateDateRange({
+		start_utc = null,
+		end_utc = null,
+		startDate = null,
+		endDate = null
+	}) {
+		this.setState(
+			{ startDate, endDate, end_utc, start_utc, page: 0 },
+			this.refreshData.bind(this)
+		);
+	}
 
-		const { organizationId, onLoad, organizationTimezone } = this.props;
-
-		const queryParams = { organization_id: organizationId, start_utc, end_utc };
+	refreshData() {
+		const { startDate, endDate, end_utc, start_utc } = this.state;
+		const {
+			organizationId,
+			onLoad,
+			organizationTimezone,
+			startUtc,
+			endUtc
+		} = this.props;
+		const queryParams = {
+			organization_id: organizationId,
+			start_utc: startUtc ? startUtc : start_utc,
+			end_utc: endUtc ? endUtc : end_utc
+		};
 
 		Bigneon()
 			.reports.boxOfficeSalesSummary(queryParams)
@@ -255,6 +268,8 @@ class BoxOfficeSalesSummary extends Component {
 			startDateDisplay,
 			endDateDisplay,
 			operators,
+			end_utc,
+			start_utc,
 			payments
 		} = this.state;
 		const isLoaded = operators && payments;
@@ -286,7 +301,9 @@ class BoxOfficeSalesSummary extends Component {
 							</Button>
 						) : null}
 						<Button
-							href={`/exports/reports/?type=box_office_sales_summary`} //TODO add date range here
+							href={`/exports/reports/?type=box_office_sales_summary${
+								start_utc ? `&start_utc=${start_utc}` : ""
+							}${end_utc ? `&end_utc=${end_utc}` : ""}`} //TODO add date range here
 							target={"_blank"}
 							iconUrl="/icons/pdf-active.svg"
 							variant="text"
@@ -305,7 +322,7 @@ class BoxOfficeSalesSummary extends Component {
 				<ReportsDate
 					defaultStartTimeBeforeNow={{ value: 0, unit: "d" }}
 					timezone={organizationTimezone}
-					onChange={this.refreshData.bind(this)}
+					onChange={this.updateDateRange.bind(this)}
 				/>
 				{this.renderGrandTotal()}
 				{this.renderOperators()}
@@ -318,6 +335,8 @@ BoxOfficeSalesSummary.propTypes = {
 	classes: PropTypes.object.isRequired,
 	organizationId: PropTypes.string.isRequired,
 	organizationTimezone: PropTypes.string.isRequired,
+	startUtc: PropTypes.string,
+	endUtc: PropTypes.string,
 	printVersion: PropTypes.bool,
 	onLoad: PropTypes.func
 };

--- a/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
+++ b/src/components/pages/admin/reports/eventSummaryAudit/SummaryAudit.js
@@ -234,15 +234,28 @@ class SummaryAudit extends Component {
 		}
 	}
 
-	refreshData(
-		dataParams = {
-			start_utc: null,
-			end_utc: null,
-			startDate: null,
-			endDate: null
-		}
-	) {
-		const { startDate, endDate, start_utc, end_utc } = dataParams;
+	updateDateRange({
+		start_utc = null,
+		end_utc = null,
+		startDate = null,
+		endDate = null
+	}) {
+		this.setState(
+			{ startDate, endDate, end_utc, start_utc, page: 0 },
+			this.refreshData.bind(this)
+		);
+	}
+
+	refreshData() {
+		const { startDate, endDate, end_utc, start_utc } = this.state;
+		const {
+			eventId,
+			organizationId,
+			onLoad,
+			organizationTimezone,
+			startUtc,
+			endUtc
+		} = this.props;
 
 		this.setState({
 			...this.initialState,
@@ -251,12 +264,11 @@ class SummaryAudit extends Component {
 			isLoading: true
 		});
 
-		const { eventId, organizationId } = this.props;
 		const summaryQueryParams = {
 			organization_id: organizationId,
 			event_id: eventId,
-			start_utc,
-			end_utc
+			start_utc: startUtc ? startUtc : start_utc,
+			end_utc: endUtc ? endUtc : end_utc
 		};
 
 		//Refresh event summary
@@ -422,6 +434,7 @@ class SummaryAudit extends Component {
 
 	render() {
 		const { printVersion, classes } = this.props;
+		const { start_utc, end_utc } = this.state;
 
 		if (printVersion) {
 			return (
@@ -458,6 +471,8 @@ class SummaryAudit extends Component {
 					<Button
 						href={`/exports/reports/?type=summary_audit&event_id=${
 							this.props.eventId
+						}${start_utc ? `&start_utc=${start_utc}` : ""}${
+							end_utc ? `&end_utc=${end_utc}` : ""
 						}`}
 						target={"_blank"}
 						iconUrl="/icons/pdf-active.svg"
@@ -470,7 +485,7 @@ class SummaryAudit extends Component {
 				{currentOrgTimezone ? (
 					<ReportsDate
 						timezone={currentOrgTimezone}
-						onChange={this.refreshData.bind(this)}
+						onChange={this.updateDateRange.bind(this)}
 						onChangeButton
 					/>
 				) : null}
@@ -497,6 +512,8 @@ SummaryAudit.propTypes = {
 	classes: PropTypes.object.isRequired,
 	organizationId: PropTypes.string.isRequired,
 	eventId: PropTypes.string.isRequired,
+	startUtc: PropTypes.string,
+	endUtc: PropTypes.string,
 	eventName: PropTypes.string,
 	printVersion: PropTypes.bool,
 	onLoad: PropTypes.func

--- a/src/components/pages/admin/reports/transactions/Transactions.js
+++ b/src/components/pages/admin/reports/transactions/Transactions.js
@@ -276,15 +276,27 @@ class Transactions extends Component {
 			organizationId,
 			onLoad,
 			printVersion,
+			startUtc,
+			endUtc,
+			isPDFExport,
 			venueTimeZone
 		} = this.props;
 
 		const limit = printVersion ? UNLIMITED_LINE_LIMIT : LINE_LIMIT_PER_PAGE;
 
+		if (isPDFExport) {
+			if (startUtc) {
+				this.setState({ start_utc: startUtc });
+			}
+			if (endUtc) {
+				this.setState({ end_utc: endUtc });
+			}
+		}
+
 		let queryParams = {
 			organization_id: organizationId,
-			start_utc,
-			end_utc,
+			start_utc: startUtc ? startUtc : start_utc,
+			end_utc: endUtc ? endUtc : end_utc,
 			page,
 			limit,
 			query: searchQuery
@@ -295,7 +307,6 @@ class Transactions extends Component {
 		}
 
 		this.setState({ startDate, endDate, items: null, isLoading: true });
-
 		const timezone = venueTimeZone || user.currentOrgTimezone;
 
 		Bigneon()
@@ -453,7 +464,13 @@ class Transactions extends Component {
 			return this.renderList();
 		}
 
-		const { isLoading, paging, isExportingCSV } = this.state;
+		const {
+			isLoading,
+			paging,
+			isExportingCSV,
+			end_utc,
+			start_utc
+		} = this.state;
 
 		const timezone = venueTimeZone || user.currentOrgTimezone;
 
@@ -499,6 +516,8 @@ class Transactions extends Component {
 						<Button
 							href={`/exports/reports/?type=transactions${
 								eventId ? `&event_id=${eventId}` : ""
+							}${start_utc ? `&start_utc=${start_utc}` : ""}${
+								end_utc ? `&end_utc=${end_utc}` : ""
 							}`}
 							target={"_blank"}
 							iconUrl="/icons/pdf-active.svg"
@@ -539,6 +558,8 @@ Transactions.propTypes = {
 	classes: PropTypes.object.isRequired,
 	organizationId: PropTypes.string.isRequired,
 	eventId: PropTypes.string,
+	startUtc: PropTypes.string,
+	endUtc: PropTypes.string,
 	eventName: PropTypes.string,
 	printVersion: PropTypes.bool,
 	onLoad: PropTypes.func,


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1151234524692625/1134088423791936
### Description:
When user runs any Big Neon report by date/time (org-level or event-level) the PDF version of the report should reflect the date/times that the user has chosen. 
### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
