### PR TITLE
Lockdown ticket pricing deletion for ones with sales

### DIFF
--- a/src/components/pages/admin/events/updateSections/PricePoint.js
+++ b/src/components/pages/admin/events/updateSections/PricePoint.js
@@ -43,7 +43,8 @@ const PricePoint = props => {
 		validateFields,
 		updatePricePointDetails,
 		onDelete,
-		isCancelled
+		isCancelled,
+		associatedWithActiveOrders
 	} = props;
 
 	return (
@@ -193,7 +194,7 @@ const PricePoint = props => {
 				/>
 			</Grid>
 
-			{!isCancelled ? (
+			{(!isCancelled && !associatedWithActiveOrders) ? (
 				<Grid
 					className={classes.inputContainer}
 					item
@@ -232,7 +233,8 @@ PricePoint.propTypes = {
 	endDate: PropTypes.object.isRequired,
 	value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
 	onDelete: PropTypes.func.isRequired,
-	isCancelled: PropTypes.bool
+	isCancelled: PropTypes.bool,
+	associatedWithActiveOrders: PropTypes.bool
 };
 
 export default withStyles(styles)(PricePoint);

--- a/src/components/pages/admin/events/updateSections/Tickets.js
+++ b/src/components/pages/admin/events/updateSections/Tickets.js
@@ -225,6 +225,7 @@ const formatForInput = (ticket_types, event) => {
 				startTime: startDate,
 				endDate: endDate.clone(),
 				endTime: endDate,
+				associatedWithActiveOrders: pricePoint.associated_with_active_orders,
 				value: price_in_cents / 100
 			});
 


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1151234524692625/1149281525498849

### Description:

This branch addresses the associated issue by locking down ticket pricing / scheduled price changes for ones with sales so they can no longer be deleted. Previously we allowed them to be deleted and it caused confusion where the clients were unaware of how the ticket pricing ever existed when they checked their event audit so this change was requested.

### Release Screenshots / Video:

Some price changes scheduled, first is prevented from being deleted as sales exist:
![Screen Shot 2019-12-16 at 10 58 26 AM](https://user-images.githubusercontent.com/1319304/70931523-a5fd7d00-2005-11ea-8335-d0591786648b.png)

After some sales for the second:
![Screen Shot 2019-12-16 at 10 59 18 AM](https://user-images.githubusercontent.com/1319304/70931565-b9a8e380-2005-11ea-94b1-464981c45950.png)

Change the price triggering a new price schedule to be created (linking to previous) and delete third:
![Screen Shot 2019-12-16 at 10 59 40 AM](https://user-images.githubusercontent.com/1319304/70931570-bdd50100-2005-11ea-8810-5970dbc6fb3e.png)

Add new price schedule not changing the others:
![Screen Shot 2019-12-16 at 11 00 10 AM](https://user-images.githubusercontent.com/1319304/70931592-c594a580-2005-11ea-91f7-38620683de4d.png)


### Environment Variables:
 * No change

### API requirements:
https://github.com/big-neon/bn-api/pull/1639
https://github.com/big-neon/bn-api-node/pull/417