### PR TITLE
Add padding between event title and event image

### DIFF
--- a/src/components/elements/event/EventHeaderImage.js
+++ b/src/components/elements/event/EventHeaderImage.js
@@ -55,7 +55,8 @@ const styles = theme => {
 			fontFamily: fontFamilyBold,
 			marginBottom: theme.spacing.unit,
 			fontSize: theme.typography.fontSize * 3,
-			lineHeight: 0.9
+			lineHeight: 0.9,
+			paddingRight: 20
 		},
 		eventNameTextLong: {
 			fontSize: theme.typography.fontSize * 1.8,
@@ -73,7 +74,8 @@ const styles = theme => {
 		withArtistsText: {
 			color: "#BFC4D2",
 			fontSize: 19,
-			lineHeight: "31px"
+			lineHeight: "31px",
+			paddingRight: 20
 		}
 	};
 };


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1156907105711882/1156291458656601
### Description:
Added 20px Padding between event name (and supporting artists text) and details card.
### Release Screenshots / Video:
Before: https://cl.ly/0bea67a3aaae
After: https://cl.ly/6b16d488d008
### Environment Variables:
 * No change

### API requirements:
