### PR TITLE
Rename tracking url and expire old tracking data

### DIFF
--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -202,20 +202,26 @@ const bigneon = {
 
 		const baseUrl = this.baseUrl;
 
+		const trackingData = user.getCampaignTrackingData();
+		let clientId = trackingData.clientId || "";
+		let source = trackingData["utm_source"] || "";
+		let medium = trackingData["utm_medium"] || "";
+
 		if (ReactGA && ReactGA.ga()) {
 			ReactGA.ga()(function(tracker) {
-				const trackingData = user.getCampaignTrackingData();
-				const clientId = tracker.get("clientId") || "";
-				const source = trackingData["utm_source"] || tracker.get("source") || "";
-				const medium = trackingData["utm_medium"] || tracker.get("medium") || "";
-				const referrer = trackingData.referrer || document.referrer;
-				img.src =
-					baseUrl +
-					`/a/t?url=${uri}&client_id=${clientId}&source=${source}&medium=${medium}&referrer=${referrer}&` +
-					data;
-				document.body.insertBefore(img, document.body.firstChild);
+				clientId = tracker.get("clientId") || clientId;
+				source = source || tracker.get("source") || "";
+				medium = medium  || tracker.get("medium") || "";
 			});
 		}
+
+		const referrer = trackingData.referrer || document.referrer;
+		const nonce = Math.random().toString(36).substr(2, 5);
+		img.src =
+			baseUrl +
+			`/a/t?n=${nonce}&url=${uri}&client_id=${clientId}&source=${source}&medium=${medium}&referrer=${referrer}&` +
+			data;
+		document.body.insertBefore(img, document.body.firstChild);
 	},
 	eventClick(id, name, category, organizationId, listPosition, list) {
 		this.track("event_id=" + id);

--- a/src/helpers/analytics.js
+++ b/src/helpers/analytics.js
@@ -211,7 +211,7 @@ const bigneon = {
 				const referrer = trackingData.referrer || document.referrer;
 				img.src =
 					baseUrl +
-					`/analytics/track?url=${uri}&client_id=${clientId}&source=${source}&medium=${medium}&referrer=${referrer}&` +
+					`/a/t?url=${uri}&client_id=${clientId}&source=${source}&medium=${medium}&referrer=${referrer}&` +
 					data;
 				document.body.insertBefore(img, document.body.firstChild);
 			});

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -8,6 +8,7 @@ import orders from "./orders";
 import errorReporting from "../helpers/errorReporting";
 import maskString from "../helpers/maskString";
 import { logoutFB } from "../components/pages/authentication/social/FacebookButton";
+import moment from "moment";
 
 class User {
 	@observable
@@ -342,7 +343,14 @@ class User {
 
 	getCampaignTrackingData() {
 		try {
-			return JSON.parse(localStorage.getItem("campaignData"));
+			const data = JSON.parse(localStorage.getItem("campaignData"));
+			if (data.expiresAt < moment()) {
+				return {};
+			}
+
+			data.expiresAt = moment().add({ hours: 24 });
+			localStorage.setItem("campaignData", JSON.stringify(data));
+			return data;
 		} catch (e) {
 			return {};
 		}
@@ -352,6 +360,7 @@ class User {
 	setCampaignTrackingData(data) {
 		let currentData = this.getCampaignTrackingData();
 		currentData = { ...currentData, ...data };
+		currentData.expiresAt = moment().add({ hours: 24 });
 		localStorage.setItem("campaignData", JSON.stringify(currentData));
 	}
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -344,7 +344,7 @@ class User {
 	getCampaignTrackingData() {
 		try {
 			const data = JSON.parse(localStorage.getItem("campaignData"));
-			if (data.expiresAt < moment()) {
+			if (moment(data.expiresAt) < moment()) {
 				return {};
 			}
 
@@ -360,6 +360,7 @@ class User {
 	setCampaignTrackingData(data) {
 		let currentData = this.getCampaignTrackingData();
 		currentData = { ...currentData, ...data };
+		currentData.clientId = currentData.clientId || `bn.${Math.random().toString(36).substr(2, 7)}.${Math.random().toString(36).substr(2, 7)}`;
 		currentData.expiresAt = moment().add({ hours: 24 });
 		localStorage.setItem("campaignData", JSON.stringify(currentData));
 	}


### PR DESCRIPTION
### References Issues:

### Description:
Rename the tracking url so that it doesn't have `analytics` in it. Some ad blockers have a regex to stop all analytics. 

Also expire the campaign tracking data after 24 hours. We've had times where the tracking data is stored for months, skewing the checkout and page view stats

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
