### PR TITLE
Revert event update venue load logic to fix permission error

### DIFF
--- a/src/components/pages/admin/events/updateSections/Details.js
+++ b/src/components/pages/admin/events/updateSections/Details.js
@@ -309,51 +309,16 @@ class Details extends Component {
 	}
 
 	componentDidMount() {
-		this.loadOrgVenueLinks();
-	}
-
-	loadOrgVenueLinks() {
-		const organization_id = user.currentOrganizationId;
-		if (organization_id) {
-			Bigneon()
-				.venues.orgVenues.index({ id: organization_id })
-				.then(response => {
-					const { data } = response.data;
-					this.setState({
-						orgVenues: data
-					});
-					this.loadVenues();
-				})
-				.catch(error => {
-					console.error(error);
-					notifications.showFromErrorResponse({
-						defaultMessage: "Loading org/venue links failed.",
-						error
-					});
-				});
-		}
+		this.loadVenues();
 	}
 
 	loadVenues() {
-		const { orgVenues } = this.state;
 		this.setState({ venues: null }, () => {
 			Bigneon()
 				.venues.index()
 				.then(response => {
-					const { data } = response.data;
-					const organizationVenues = [];
-
-					if (orgVenues.length > 0) {
-						for (let i = 0; i < orgVenues.length; i++) {
-							data.forEach(venue => {
-								if (venue.id === orgVenues[i].venue_id) {
-									organizationVenues.push(venue);
-								}
-							});
-						}
-					}
-
-					this.setState({ venues: organizationVenues });
+					const { data, paging } = response.data; //@TODO Implement pagination
+					this.setState({ venues: data });
 
 					//If it's a new event and there is only one private venue available then auto select that one
 					const privateVenues = data.filter(v => v.is_private);


### PR DESCRIPTION
### References Issues:
N/A

### Description:
It was noticed in production clients were unable to update events as they lacked permissions to access the venues. It looks like we updated the logic in the events update to point to the organization venues endpoint instead of the venues. The API side updated the venues endpoint so it takes into account the organization venue links so we didn't need to. The other endpoint it is using now is admin only so it's causing some errors for those clients.

### Release Screenshots / Video:
Current behavior:
<img width="916" alt="Screen Shot 2020-02-26 at 4 50 08 PM" src="https://user-images.githubusercontent.com/1319304/75391441-118e8100-58b8-11ea-964e-bd1cf7c62c44.png">

With the logic reverted:
<img width="775" alt="Screen Shot 2020-02-26 at 4 46 48 PM" src="https://user-images.githubusercontent.com/1319304/75391464-1c491600-58b8-11ea-92b4-c29705b17336.png">


### Environment Variables:
 * No change

### API requirements:
N/A