### PR TITLE
Push call round off notifications opened number

### DIFF
--- a/src/components/pages/admin/events/dashboard/fanNotifications/sections/NotificationProgress.js
+++ b/src/components/pages/admin/events/dashboard/fanNotifications/sections/NotificationProgress.js
@@ -31,7 +31,7 @@ class NotificationProgress extends Component {
 					<Typography className={classes.descriptionHeading}>
 						Notifications Opened{" "}
 						<span className={classes.percentage}>
-							{scheduleProgress === null ? "0" : completed}%
+							{scheduleProgress === null ? "0" : +completed.toFixed(2)}%
 						</span>
 					</Typography>
 					<LinearProgress


### PR DESCRIPTION
### References Issues:
https://app.asana.com/0/1158142652422330/1160462791103763/f
### Description:
The percentage for number of notifications opened, was not rounded off. Was asked to round off to the 10th place.
### Release Screenshots / Video:
https://share.getcloudapp.com/5zuyNy52
### Environment Variables:
 * No change

### API requirements:
