### PR TITLE
Send login tokens to mobile

### DIFF
--- a/src/components/pages/authentication/forms/LoginForm.js
+++ b/src/components/pages/authentication/forms/LoginForm.js
@@ -13,6 +13,7 @@ import PasswordResetDialog from "../PasswordResetDialog";
 import Bigneon from "../../../../helpers/bigneon";
 import Recaptcha from "../../../common/Recaptcha";
 import analytics from "../../../../helpers/analytics";
+import { isReactNative, sendReactNativeMessage, useNewMessaging, MESSAGE_TYPES } from "../../../../helpers/reactNative";
 
 const styles = () => ({});
 
@@ -118,6 +119,14 @@ class LoginForm extends Component {
 						}
 
 						analytics.identify({ ...newUser, method: "login" });
+
+						if (isReactNative() && useNewMessaging()) {
+							const loginData = {
+								refresh_token,
+								access_token
+							};
+							sendReactNativeMessage(loginData, MESSAGE_TYPES.AUTH);
+						}
 
 						//If we have a security token, send them to the accept invite page first
 						const security_token = localStorage.getItem("security_token");

--- a/src/helpers/reactNative.js
+++ b/src/helpers/reactNative.js
@@ -2,7 +2,8 @@ import getAllUrlParams from "./getAllUrlParams";
 
 export const MESSAGE_TYPES = {
 	STRIPE: "stripe",
-	NAVIGATION: "navigation"
+	NAVIGATION: "navigation",
+	AUTH: "auth"
 };
 
 export const isReactNative = () => {


### PR DESCRIPTION
### References Issues:

[Asana](https://app.asana.com/0/1141185905028320/1168967382452721/f)

### Description:

After a successful login in web view tokens along with user data are sent to the mobile app so that the user would get logged in in the app at the same time.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
