### PR TITLE
Send tokens to mobile on FB signup

### DIFF
--- a/src/components/pages/authentication/social/FacebookButton.js
+++ b/src/components/pages/authentication/social/FacebookButton.js
@@ -8,6 +8,7 @@ import notifications from "../../../../stores/notifications";
 import user from "../../../../stores/user";
 import Bigneon from "../../../../helpers/bigneon";
 import servedImage from "../../../../helpers/imagePathHelper";
+import { isReactNative, sendReactNativeMessage, useNewMessaging, MESSAGE_TYPES } from "../../../../helpers/reactNative";
 
 const styles = theme => ({
 	leftIcon: {
@@ -108,6 +109,14 @@ class FacebookButtonDisplay extends Component {
 					if (access_token) {
 						localStorage.setItem("access_token", access_token);
 						localStorage.setItem("refresh_token", refresh_token);
+
+						if (isReactNative() && useNewMessaging()) {
+							const loginData = {
+								refresh_token,
+								access_token
+							};
+							sendReactNativeMessage(loginData, MESSAGE_TYPES.AUTH);
+						}
 
 						//Pull user data with our new token
 						user.refreshUser(({ email }) => {


### PR DESCRIPTION
### References Issues:

### Description:

Sends tokens to mobile after successful login with facebook.

### Release Screenshots / Video:

### Environment Variables:
 * No change

### API requirements:
